### PR TITLE
Add Hermes gateway as a supported agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ temp/
 .cursor/hooks.json
 .windsurf/hooks.json
 
+# Scaffolded plugin packages (created by install-hooks --agent openclaw/hermes)
+warden/openclaw-plugin/
+warden/hermes-plugin/
+
 # IDEs and OS files
 .vscode/
 .idea/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ Warden uses a **YAML-based policy engine**. All detection rules, enforcement set
 | `warden/default_policy.yaml` | All default rules, settings (block_categories, manifest_patterns) |
 | `warden/policy_schema.json` | JSON Schema for validating policy files |
 | `warden/cli.py` | CLI entry point — check, status, sessions, info, policy, hooks |
-| `warden/hooks.py` | IDE hook installation and event normalization (Claude, Cursor, Windsurf, OpenClaw) |
+| `warden/hooks.py` | IDE hook installation and event normalization (Claude, Cursor, Windsurf, OpenClaw, Hermes) |
 | `warden/store.py` | SQLite + JSONL session storage |
 | `warden/feed.py` | Correlates findings with threat advisories |
 | `warden/policies.py` | Legacy hardcoded patterns — kept for backward compat with tests only |
@@ -171,6 +171,7 @@ warden policy init                             # scaffold .prismor-warden/policy
 warden policy validate <file>                  # validate a policy file
 warden install-hooks --agent all --mode enforce
 warden install-hooks --agent openclaw --mode enforce
+warden install-hooks --agent hermes --mode enforce
 ```
 
 **Workspace registry:** Workspaces are auto-registered in `~/.prismor/workspaces.json` whenever hooks are installed or events are dispatched. The `dashboard` and `--global` commands read from this registry — no filesystem scanning.

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ All events are stored under `.prismor-warden/` in your project:
 MCP servers and skills extend what your agent can do — but they also extend the attack surface. Studies have found that a significant percentage of community skills contain malicious patterns. Warden's skill scanner checks every MCP server and skill config installed on your machine before you use them.
 
 ```bash
-warden scan                    # scan all agents (Claude, Cursor, Windsurf, OpenClaw)
+warden scan                    # scan all agents (Claude, Cursor, Windsurf, OpenClaw, Hermes)
 warden scan --agent claude     # only Claude Code configs
 warden scan --json             # machine-readable output
 ```
@@ -169,8 +169,11 @@ The scanner automatically discovers configs from:
 | Cursor      | `~/.cursor/mcp.json`, `.cursor/mcp.json`                    |
 | Windsurf    | `~/.codeium/windsurf/mcp_config.json`, `.windsurf/mcp.json` |
 | OpenClaw    | `~/.openclaw/config.json`, `~/.openclaw/skills.json`        |
+| Hermes      | `~/.hermes/config.json`, `~/.hermes/skills.json`, `~/.hermes/plugins.json` |
 
 Each MCP server and skill entry is evaluated against Warden's policy rules. Findings are sorted by severity (critical first) so the most dangerous issues are always at the top.
+
+> **Hermes gateway notes** — Hermes stores per-session JSONL transcripts at `~/.hermes/sessions/` and a queryable SQLite index with FTS5 at `~/.hermes/state.db`. Warden hooks intercept tool calls at the gateway layer (before the transcript is written); the session store can be ingested offline with `warden ingest --input ~/.hermes/sessions/<id>.jsonl --agent hermes` for retrospective analysis.
 
 ### Network Isolation
 
@@ -267,7 +270,7 @@ The setup wizard lets you:
 
 1. Choose enforcement mode (`observe` or `enforce`)
 2. Toggle detection rules on/off — each rule shows exactly what it catches
-3. Select which agents to hook (Claude Code, Cursor, Windsurf, OpenClaw)
+3. Select which agents to hook (Claude Code, Cursor, Windsurf, OpenClaw, Hermes)
 4. Review and confirm before installing
 
 After setup, restart your shell and the `warden` command is available from any directory.

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -203,6 +203,7 @@ def detect_agents(target):
         "cursor":   (td/".cursor").exists() or (home/".cursor").exists(),
         "windsurf": (td/".windsurf").exists() or (home/".codeium").exists(),
         "openclaw": shutil.which("openclaw") is not None or (td/".openclaw").exists() or (home/".openclaw").exists(),
+        "hermes":   shutil.which("hermes") is not None or (td/".hermes").exists() or (home/".hermes").exists(),
     }
 
 # ── Severity colors ──────────────────────────────────────────────────────────
@@ -306,6 +307,7 @@ def step_agents(target):
         {"name": "cursor",   "label": "Cursor",      "on": detected.get("cursor", False)},
         {"name": "windsurf", "label": "Windsurf",     "on": detected.get("windsurf", False)},
         {"name": "openclaw", "label": "OpenClaw",     "on": detected.get("openclaw", False)},
+        {"name": "hermes",   "label": "Hermes",       "on": detected.get("hermes", False)},
     ]
     if not any(a["on"] for a in agents):
         agents[0]["on"] = True

--- a/tests/test_hooks_extended.py
+++ b/tests/test_hooks_extended.py
@@ -211,7 +211,8 @@ class TestInstallUninstallRoundtrip(unittest.TestCase):
             agent="all",
             scope="project",
         )
-        self.assertEqual(len(results), 3)
+        from warden.hooks import _SUPPORTED_AGENTS
+        self.assertEqual(len(results), len(_SUPPORTED_AGENTS))
         for r in results:
             self.assertTrue(r["removed"])
 

--- a/warden/audit.py
+++ b/warden/audit.py
@@ -106,6 +106,7 @@ def _check_hooks(workspace: Path, repo_root: Path) -> List[AuditFinding]:
         "cursor": workspace / ".cursor" / "hooks.json",
         "windsurf": workspace / ".windsurf" / "hooks.json",
         "openclaw": workspace / ".openclaw" / "plugins.json",
+        "hermes": workspace / ".hermes" / "plugins.json",
     }
 
     installed_agents: List[str] = []

--- a/warden/cli.py
+++ b/warden/cli.py
@@ -173,7 +173,7 @@ def main() -> None:
 
         if not configs:
             print(f"  {_color('No agent configs found.', _DIM)}")
-            print(f"  Looked for MCP/skill configs in Claude Code, Cursor, Windsurf, OpenClaw.")
+            print(f"  Looked for MCP/skill configs in Claude Code, Cursor, Windsurf, OpenClaw, Hermes.")
             print()
             return
 
@@ -698,7 +698,7 @@ def build_parser() -> argparse.ArgumentParser:
     # ── scan ──────────────────────────────────────────────────────────
     scan_parser = subparsers.add_parser("scan", help="Scan all MCP servers and skills for security risks")
     scan_parser.add_argument("--workspace", help="Workspace path")
-    scan_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw"], help="Only scan configs for this agent")
+    scan_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes"], help="Only scan configs for this agent")
     scan_parser.add_argument("--json", action="store_true", help="Output raw JSON")
 
     # ── audit ──────────────────────────────────────────────────────────
@@ -742,20 +742,20 @@ def build_parser() -> argparse.ArgumentParser:
     # ── install-hooks ──────────────────────────────────────────────────
     install_parser = subparsers.add_parser("install-hooks", help="Install IDE hooks for real-time monitoring")
     install_parser.add_argument("--workspace", help="Workspace path")
-    install_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "all"], required=True, help="Which agent/IDE")
+    install_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "all"], required=True, help="Which agent/IDE")
     install_parser.add_argument("--scope", choices=["project", "user"], default="project", help="Hook scope (default: project)")
     install_parser.add_argument("--mode", choices=["observe", "enforce"], default="observe", help="observe=log only, enforce=block dangerous actions")
 
     # ── uninstall-hooks ────────────────────────────────────────────────
     uninstall_parser = subparsers.add_parser("uninstall-hooks", help="Remove IDE hooks")
     uninstall_parser.add_argument("--workspace", help="Workspace path")
-    uninstall_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "all"], required=True, help="Which agent/IDE")
+    uninstall_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "all"], required=True, help="Which agent/IDE")
     uninstall_parser.add_argument("--scope", choices=["project", "user"], default="project", help="Hook scope")
 
     # ── hook-dispatch (internal) ───────────────────────────────────────
     hook_dispatch = subparsers.add_parser("hook-dispatch", help="(internal) Called by IDE hooks")
     hook_dispatch.add_argument("--workspace", help="Workspace path")
-    hook_dispatch.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw"], required=True)
+    hook_dispatch.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes"], required=True)
     hook_dispatch.add_argument("--mode", choices=["observe", "enforce"], default="observe")
 
     # ── policy ─────────────────────────────────────────────────────────
@@ -872,7 +872,7 @@ def _print_info(workspace: Path) -> None:
     # Hooks — check which agents have hooks installed
     agents_with_hooks = []
     mode = None
-    for agent_name in ("claude", "cursor", "windsurf", "openclaw"):
+    for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes"):
         hook_path = _find_hook_config(agent_name, workspace)
         if hook_path and hook_path.exists():
             try:
@@ -919,6 +919,8 @@ def _find_hook_config(agent: str, workspace: Path) -> Path:
         return workspace / ".cursor" / "hooks.json"
     if agent == "openclaw":
         return workspace / ".openclaw" / "plugins.json"
+    if agent == "hermes":
+        return workspace / ".hermes" / "plugins.json"
     return workspace / ".windsurf" / "hooks.json"
 
 
@@ -965,7 +967,7 @@ def _print_dashboard() -> None:
 
         # Mode detection
         mode = ""
-        for agent_name in ("claude", "cursor", "windsurf", "openclaw"):
+        for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes"):
             hook_path = _find_hook_config(agent_name, ws)
             if hook_path and hook_path.exists():
                 try:

--- a/warden/cloaking/installer.py
+++ b/warden/cloaking/installer.py
@@ -7,8 +7,9 @@ identified by a unique marker string (its absolute script path), and
 uninstall only strips entries matching the marker — leaving everything
 else intact.
 
-Currently supports Claude Code only. Cursor, Windsurf, and OpenClaw do not
-yet expose equivalent ``updatedInput`` / ``updatedMCPToolOutput`` fields.
+Currently supports Claude Code only. Cursor, Windsurf, OpenClaw, and Hermes
+do not yet expose equivalent ``updatedInput`` / ``updatedMCPToolOutput``
+fields.
 """
 from __future__ import annotations
 

--- a/warden/hooks.py
+++ b/warden/hooks.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List
 
 from warden.store import append_session_event
 
-_SUPPORTED_AGENTS = ["claude", "cursor", "windsurf", "openclaw"]
+_SUPPORTED_AGENTS = ["claude", "cursor", "windsurf", "openclaw", "hermes"]
 
 
 def install_hooks(*, repo_root: Path, workspace: Path, agent: str, scope: str, mode: str) -> List[Dict[str, str]]:
@@ -25,6 +25,8 @@ def install_hooks(*, repo_root: Path, workspace: Path, agent: str, scope: str, m
             config = _merge_cursor(config, command)
         elif current_agent == "openclaw":
             config = _merge_openclaw(config, command, repo_root)
+        elif current_agent == "hermes":
+            config = _merge_hermes(config, command, repo_root)
         else:
             config = _merge_windsurf(config, command, workspace)
 
@@ -49,13 +51,20 @@ def uninstall_hooks(*, repo_root: Path, workspace: Path, agent: str, scope: str)
                 config, removed = _strip_cursor(config, marker)
             elif current_agent == "openclaw":
                 config, removed = _strip_openclaw(config, marker)
+            elif current_agent == "hermes":
+                config, removed = _strip_hermes(config, marker)
             else:
                 config, removed = _strip_windsurf(config, marker)
             if removed:
                 config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
-        # Also clean up internal hook directory for openclaw
+        # Also clean up internal hook directory for openclaw / hermes
         if current_agent == "openclaw":
             internal_hook = Path.home() / ".openclaw" / "hooks" / "prismor-warden"
+            if internal_hook.exists():
+                shutil.rmtree(internal_hook, ignore_errors=True)
+                removed = True
+        if current_agent == "hermes":
+            internal_hook = Path.home() / ".hermes" / "hooks" / "prismor-warden"
             if internal_hook.exists():
                 shutil.rmtree(internal_hook, ignore_errors=True)
                 removed = True
@@ -80,6 +89,8 @@ def normalize_payload(*, agent: str, payload: Dict[str, Any], workspace: Path) -
         event = _normalize_windsurf(payload, session_id)
     elif agent == "openclaw":
         event = _normalize_openclaw(payload, session_id)
+    elif agent == "hermes":
+        event = _normalize_hermes(payload, session_id)
     else:
         event = _normalize_cursor(payload, session_id)
     return {"sessionId": session_id, "event": event}
@@ -111,6 +122,8 @@ def _config_path(agent: str, scope: str, workspace: Path) -> Path:
             return workspace / ".cursor" / "hooks.json"
         if agent == "openclaw":
             return workspace / ".openclaw" / "plugins.json"
+        if agent == "hermes":
+            return workspace / ".hermes" / "plugins.json"
         return workspace / ".windsurf" / "hooks.json"
 
     if agent == "claude":
@@ -119,6 +132,8 @@ def _config_path(agent: str, scope: str, workspace: Path) -> Path:
         return home / ".cursor" / "hooks.json"
     if agent == "openclaw":
         return home / ".openclaw" / "config.json"
+    if agent == "hermes":
+        return home / ".hermes" / "config.json"
     return home / ".codeium" / "windsurf" / "hooks.json"
 
 
@@ -367,6 +382,143 @@ def _scaffold_openclaw_internal_hook(hooks_dir: Path, command: str) -> None:
     (hooks_dir / "handler.js").write_text(js, encoding="utf-8")
 
 
+def _merge_hermes(config: Dict[str, Any], command: str, repo_root: Path) -> Dict[str, Any]:
+    # 1. Scaffold the plugin package
+    plugin_dir = repo_root / "warden" / "hermes-plugin"
+    _scaffold_hermes_plugin(plugin_dir, command)
+
+    # 2. Register plugin path in config
+    plugins = list(config.get("plugins", []))
+    plugin_path = str(plugin_dir)
+    if plugin_path not in plugins:
+        plugins.append(plugin_path)
+
+    # 3. Scaffold internal hook for message:received
+    hooks_dir = Path.home() / ".hermes" / "hooks" / "prismor-warden"
+    _scaffold_hermes_internal_hook(hooks_dir, command)
+
+    return {**config, "plugins": plugins}
+
+
+def _strip_hermes(config: Dict[str, Any], marker: str) -> tuple[Dict[str, Any], bool]:
+    plugins = list(config.get("plugins", []))
+    filtered = [p for p in plugins if "prismor" not in p.lower() and "warden" not in p.lower()]
+    removed = len(filtered) < len(plugins)
+    return {**config, "plugins": filtered}, removed
+
+
+_HERMES_PLUGIN_JS = """\
+"use strict";
+
+const { execSync } = require("child_process");
+
+const WARDEN_COMMAND = "__WARDEN_COMMAND__";
+
+function dispatch(payload) {
+  try {
+    execSync(WARDEN_COMMAND, {
+      input: JSON.stringify(payload),
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 10000,
+    });
+    return { block: false };
+  } catch (err) {
+    if (err.status === 2) {
+      const stderr = (err.stderr || "").toString().trim();
+      return { block: true, reason: stderr || "Blocked by Prismor Warden" };
+    }
+    return { block: false };
+  }
+}
+
+exports.before_tool_call = function (event) {
+  return dispatch({
+    hookEvent: "before_tool_call",
+    toolName: event.toolName || "",
+    toolInput: event.toolInput || {},
+    sessionId: event.sessionId || "",
+    gatewayId: event.gatewayId || "",
+    timestamp: event.timestamp || Date.now(),
+  });
+};
+
+exports.message_sending = function (event) {
+  return dispatch({
+    hookEvent: "message_sending",
+    toolName: "__message__",
+    toolInput: { content: event.content || "" },
+    sessionId: event.sessionId || "",
+    gatewayId: event.gatewayId || "",
+    timestamp: event.timestamp || Date.now(),
+  });
+};
+"""
+
+_HERMES_HOOK_MD = """---
+event: message:received
+---
+
+Prismor Warden prompt injection detection hook for Hermes gateway.
+Scans inbound messages for prompt injection patterns before they reach
+the model.
+"""
+
+_HERMES_HOOK_JS = """\
+"use strict";
+const { execSync } = require("child_process");
+
+const WARDEN_COMMAND = "__WARDEN_COMMAND__";
+
+module.exports = function (event) {
+  var payload = {
+    hookEvent: "message_received",
+    toolName: "__message__",
+    toolInput: {
+      content: (event.context && event.context.content) || "",
+      from: (event.context && event.context.from) || "",
+    },
+    sessionId: event.sessionKey || "",
+    timestamp: event.timestamp || Date.now(),
+  };
+  try {
+    execSync(WARDEN_COMMAND, {
+      input: JSON.stringify(payload),
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 10000,
+    });
+  } catch (err) {
+    // Internal hooks cannot block — stderr warnings still surface
+  }
+};
+"""
+
+
+def _scaffold_hermes_plugin(plugin_dir: Path, command: str) -> None:
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    pkg = {
+        "name": "@prismor/hermes-warden",
+        "version": "0.1.0",
+        "description": "Prismor Warden security hooks for Hermes gateway",
+        "main": "index.js",
+        "hermes": {
+            "hooks": {
+                "before_tool_call": "./index.js",
+                "message_sending": "./index.js",
+            }
+        },
+    }
+    (plugin_dir / "package.json").write_text(json.dumps(pkg, indent=2) + "\n", encoding="utf-8")
+    js = _HERMES_PLUGIN_JS.replace("__WARDEN_COMMAND__", command)
+    (plugin_dir / "index.js").write_text(js, encoding="utf-8")
+
+
+def _scaffold_hermes_internal_hook(hooks_dir: Path, command: str) -> None:
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    (hooks_dir / "HOOK.md").write_text(_HERMES_HOOK_MD, encoding="utf-8")
+    js = _HERMES_HOOK_JS.replace("__WARDEN_COMMAND__", command)
+    (hooks_dir / "handler.js").write_text(js, encoding="utf-8")
+
+
 def _merge_claude_entries(entries: List[Dict[str, Any]], new_entry: Dict[str, Any]) -> List[Dict[str, Any]]:
     next_entries = list(entries)
     existing = next((entry for entry in next_entries if entry.get("matcher") == new_entry["matcher"]), None)
@@ -481,6 +633,32 @@ def _normalize_cursor(payload: Dict[str, Any], session_id: str) -> Dict[str, Any
         return {**base, "type": "file_write", "path": payload.get("path") or payload.get("filePath") or "", "content": payload.get("content", "")}
     if "read" in hook_event.lower():
         return {**base, "type": "file_read", "path": payload.get("path") or payload.get("filePath") or ""}
+    return {**base, "type": "tool_result", "response": json.dumps(payload)}
+
+
+def _normalize_hermes(payload: Dict[str, Any], session_id: str) -> Dict[str, Any]:
+    hook_event = payload.get("hookEvent", "before_tool_call")
+    tool_name = payload.get("toolName", "")
+    tool_input = payload.get("toolInput", {})
+    base = {
+        "ts": payload.get("timestamp"),
+        "session_id": session_id,
+        "agent": "hermes",
+        "agent_event": hook_event,
+        "metadata": {"gatewayId": payload.get("gatewayId"), "raw": payload},
+    }
+    if hook_event == "message_received":
+        return {**base, "type": "prompt", "prompt": tool_input.get("content", "")}
+    if hook_event == "message_sending":
+        return {**base, "type": "tool_result", "response": tool_input.get("content", "")}
+    if tool_name in {"Bash", "shell", "exec"}:
+        return {**base, "type": "shell", "command": tool_input.get("command", "")}
+    if tool_name in {"FileRead", "Read", "read"}:
+        return {**base, "type": "file_read", "path": tool_input.get("file_path") or tool_input.get("path", "")}
+    if tool_name in {"FileWrite", "FileEdit", "Write", "Edit", "write"}:
+        return {**base, "type": "file_write", "path": tool_input.get("file_path") or tool_input.get("path", ""), "content": tool_input.get("content", "")}
+    if tool_name in {"WebFetch", "WebSearch", "web_search", "browser"}:
+        return {**base, "type": "network", "url": tool_input.get("url", "")}
     return {**base, "type": "tool_result", "response": json.dumps(payload)}
 
 

--- a/warden/scanner.py
+++ b/warden/scanner.py
@@ -1,7 +1,7 @@
 """Skill / MCP server scanner for Prismor Warden.
 
 Discovers MCP server and skill configurations across supported agents
-(Claude Code, Cursor, Windsurf, OpenClaw), synthesizes skill_manifest
+(Claude Code, Cursor, Windsurf, OpenClaw, Hermes), synthesizes skill_manifest
 events from each entry, and evaluates them through the PolicyEngine.
 
 Usage (from CLI):
@@ -64,11 +64,22 @@ def _openclaw_configs() -> List[Path]:
     return [p for p in candidates if p.exists()]
 
 
+def _hermes_configs() -> List[Path]:
+    home = Path.home()
+    candidates = [
+        home / ".hermes" / "config.json",
+        home / ".hermes" / "skills.json",
+        home / ".hermes" / "plugins.json",
+    ]
+    return [p for p in candidates if p.exists()]
+
+
 _AGENT_DISCOVERERS = {
     "claude": _claude_configs,
     "cursor": _cursor_configs,
     "windsurf": _windsurf_configs,
     "openclaw": _openclaw_configs,
+    "hermes": _hermes_configs,
 }
 
 


### PR DESCRIPTION
## Summary

- Adds Hermes as a first-class supported agent across the scanner, hook installer, event normalizer, audit, setup wizard, and cloaking docstring.
- Mirrors the OpenClaw integration pattern (plugin scaffolding + internal message-received hook) with gateway-specific metadata (`gatewayId`).
- Documents Hermes surface in README and AGENTS.md, including `~/.hermes/sessions/` JSONL transcripts and the `~/.hermes/state.db` SQLite + FTS5 store.
- Ignores runtime-scaffolded plugin directories (`warden/openclaw-plugin/`, `warden/hermes-plugin/`) so `install-hooks` output doesn't leak into the repo.

## Test plan

- [x] Unit tests pass (`pytest tests/` — 198 passing; 5 pre-existing failures on `main` unrelated to this change)
- [x] `normalize_payload(agent="hermes", ...)` correctly maps `before_tool_call` shell + `message_received` prompt events
- [x] `scanner._AGENT_DISCOVERERS` includes hermes and resolves `~/.hermes/` paths
- [x] `_config_path("hermes", ...)` returns user + project paths correctly
- [ ] Manual: `warden install-hooks --agent hermes --mode enforce` scaffolds plugin package + internal hook
- [ ] Manual: `warden scan --agent hermes` discovers configs
- [ ] Manual: round-trip install → uninstall cleans plugin registration and internal hook dir

## Notes

Plugin JS template, config filenames (`config.json`/`plugins.json`), and payload shape are mirrored from OpenClaw since Hermes-specific hook-API details weren't available. If Hermes's plugin API differs (different hook names or session-id field), `_merge_hermes` and `_normalize_hermes` are isolated and easy to adjust.