### PR TITLE
Add Trae and Kilocode to sweep scan targets

### DIFF
--- a/AGENT_INTEGRATIONS.md
+++ b/AGENT_INTEGRATIONS.md
@@ -24,8 +24,8 @@ _Last updated: 2026-04-21._
 | VS Code Copilot Chat | 🟡 roadmap (preview) | — | — | `PreToolUse` hook |
 | Google Antigravity | — | ✅ | — | no hooks — rules + interactive permissions |
 | Aider | — | — | — | `CONVENTIONS.md` — no hooks |
-| Trae / Trae CN | — | — | — | `.trae/rules/` — no hooks (MCP is the only dynamic surface) |
-| Kilocode | soft only | — | — | `session.chat.before` injects guardrail prompt, can't veto |
+| Trae / Trae CN | — | ✅ | — | `.trae/rules/` — no hooks (MCP is the only dynamic surface) |
+| Kilocode | soft only | ✅ | — | `session.chat.before` injects guardrail prompt, can't veto |
 
 ✅ shipped · 🟡 planned (adapter not implemented) · — not applicable
 
@@ -158,13 +158,13 @@ These agents don't expose a programmable pre-tool hook. Integration is limited t
 
 - **Hooks:** none. MCP is the only dynamic surface — wrapping Warden as an MCP proxy is feasible but out of scope.
 - **Surface:** `.trae/rules/` markdown + MCP server registration.
-- **Config dir:** `~/.trae/`, workspace `.trae/rules/` and `.trae/agents/`.
+- **Config dir:** `~/.trae/` (scanned by `warden sweep`), workspace `.trae/rules/` and `.trae/agents/`.
 
 ### Kilocode
 
 - **Hooks:** soft only. `session.chat.before` can inject a guardrail prompt into chat params but cannot veto a tool call. Tool filtering is permission/approval UI, not programmable.
 - **Surface:** `AGENTS.md`, `.kilocode/rules/`, `kilo.jsonc`; plugin can inject prompt-level policy.
-- **Config dir:** `~/.kilocode/`, workspace `.kilocode/rules/`.
+- **Config dir:** `~/.kilocode/` (scanned by `warden sweep`), workspace `.kilocode/rules/`.
 
 ---
 

--- a/warden/sweep.py
+++ b/warden/sweep.py
@@ -30,6 +30,8 @@ TOOL_DIRS: dict[str, Path] = {
     "antigravity": Path.home() / ".antigravity",
     "cursor": Path.home() / ".config" / "Cursor",
     "claude": Path.home() / ".claude",
+    "trae": Path.home() / ".trae",
+    "kilocode": Path.home() / ".kilocode",
 }
 
 # Config files that should NEVER be redacted (they hold keys the tools need)


### PR DESCRIPTION
## Summary

- Add `~/.trae/` and `~/.kilocode/` to `TOOL_DIRS` in `warden/sweep.py` so `warden sweep` picks up leaked secrets from Trae and Kilocode config directories.
- Update the sweep-scan column and config-dir notes in `AGENT_INTEGRATIONS.md` to reflect coverage.

## Why

Both agents store config under a home-level dotfolder and have no runtime hook API (Trae has none; Kilocode's `session.chat.before` is soft only), so sweep is the only useful integration surface. Missing dirs are skipped by the existing `path.is_dir()` check in `scan()`, so adding these is a no-op for users who don't have those agents installed.

## Not in this PR

- Aider — config is `~/.aider.conf.yml` (a file, not a directory), so it doesn't fit the `TOOL_DIRS` pattern. Needs a separate single-file scan path.

## Test plan

- [ ] `warden sweep` runs cleanly on a machine without Trae/Kilocode installed (expected: silent skip)
- [ ] `warden sweep` picks up files when `~/.trae/` or `~/.kilocode/` contains a leaked-secret fixture