### PR TITLE
Add Gemini CLI hook adapter, sweep target, and skill scan

### DIFF
--- a/AGENT_INTEGRATIONS.md
+++ b/AGENT_INTEGRATIONS.md
@@ -15,8 +15,8 @@ _Last updated: 2026-04-21._
 | Windsurf | ✅ | ✅ | ✅ | `.windsurf/hooks.json` |
 | OpenClaw | ✅ | — | ✅ | JS plugin at `~/.openclaw/hooks/` |
 | Hermes | ✅ | — | ✅ | JS plugin at `~/.hermes/hooks/` |
+| Gemini CLI | ✅ | ✅ | ✅ | `~/.gemini/settings.json` hooks block |
 | Codex (OpenAI) | 🟡 partial | ✅ | — | `~/.codex/hooks.json` (experimental, Bash-only) |
-| Gemini CLI | 🟡 roadmap | — | — | `settings.json` hooks block (stable) |
 | OpenCode | 🟡 roadmap | — | — | JS plugin `tool.execute.before` |
 | Kiro | 🟡 roadmap | — | — | `preToolUse` hooks (exit-2 blocks) |
 | Factory Droid | 🟡 roadmap | — | — | `PreToolUse` plugin (`permissionDecision`) |
@@ -70,11 +70,20 @@ _Last updated: 2026-04-21._
 - **Session ingest:** offline analysis of `~/.hermes/sessions/*.jsonl` via `warden ingest --input <file> --agent hermes`.
 - **Code:** `warden/hooks.py` `_merge_hermes()`, `_normalize_hermes()`.
 
+### Gemini CLI (Google)
+
+- **Config:** `.gemini/settings.json` (project) or `~/.gemini/settings.json` (user). Hooks block merges into the existing `hooks` object — co-exists with user-defined hooks.
+- **Events hooked:** `BeforeTool`, `AfterTool` (matcher `.*`), `BeforeAgent`. Additional Gemini events (`BeforeModel`, `BeforeToolSelection`, `AfterModel`, `SessionStart`, `SessionEnd`, `Notification`, `PreCompress`) are available but not wired by default — add them manually if needed.
+- **Blocking:** exit 2 from hook → "System Block"; stderr → rejection reason (sent to the agent as a tool error for tool events, aborts the turn for agent events). Exit 0 with empty stdout = allow (silence-on-stdout is the Gemini convention).
+- **Sweep target:** `~/.gemini/`.
+- **Skill scan:** `mcpServers` block in `~/.gemini/settings.json` or `.gemini/settings.json`.
+- **Code:** `warden/hooks.py` `_merge_gemini()`, `_normalize_gemini()`.
+
 ---
 
 ## Roadmap — hook adapters planned
 
-Each agent below exposes a blocking pre-tool hook. An adapter requires (1) config-merge in `warden/hooks.py`, (2) `_normalize_*` function, (3) registration in `_SUPPORTED_AGENTS` and `warden/store.py`, (4) sweep target in `warden/sweep.py` if applicable.
+Each agent below exposes a blocking pre-tool hook. An adapter requires (1) config-merge in `warden/hooks.py`, (2) `_normalize_*` function, (3) registration in `_SUPPORTED_AGENTS`, (4) sweep target in `warden/sweep.py` if applicable.
 
 ### Codex (OpenAI) — partial
 
@@ -85,15 +94,6 @@ Each agent below exposes a blocking pre-tool hook. An adapter requires (1) confi
 - **Blocking:** exit 2 → block, stderr → reason. `PreToolUse` and `PermissionRequest` support `systemMessage` output.
 - **Sweep target:** `~/.codex/` (already covered).
 - **Adapter work:** payload shape mirrors Claude Code — `_normalize_claude` can be reused with minor field renames. Document the `apply_patch` blind spot to users.
-
-### Gemini CLI (Google)
-
-- **Status:** stable — launched as a core feature on the [Google Developers Blog](https://developers.googleblog.com/tailor-gemini-cli-to-your-workflow-with-hooks/). Cleanest drop-in of the roadmap set.
-- **Config:** `.gemini/settings.json` (project) → `~/.gemini/settings.json` (user) → `/etc/gemini-cli/settings.json` (system), layered. `hooks.<Event>[].matcher` + `.hooks[]` with `{name, type: "command", command, timeout}`.
-- **Events:** `BeforeTool`, `AfterTool`, `BeforeAgent`, `AfterAgent`, `BeforeModel`, `BeforeToolSelection`, `AfterModel`, `SessionStart`, `SessionEnd`, `Notification`, `PreCompress`.
-- **Payload:** JSON on stdin — shared `session_id`, `transcript_path`, `cwd`, `hook_event_name`, `timestamp`, plus event-specific fields (`tool_name`, `prompt`, etc.).
-- **Blocking:** exit 2 → "System Block" (stderr → rejection reason; for tool events blocks the call but agent continues; for agent/model events aborts the turn). Other non-zero exits → non-fatal warning.
-- **Adapter work:** write hooks block into `~/.gemini/settings.json`, map `BeforeTool`→pre, `AfterTool`→post, `SessionStart`. Reuse Claude-shape normalizer.
 
 ### OpenCode
 

--- a/warden/cli.py
+++ b/warden/cli.py
@@ -698,7 +698,7 @@ def build_parser() -> argparse.ArgumentParser:
     # ── scan ──────────────────────────────────────────────────────────
     scan_parser = subparsers.add_parser("scan", help="Scan all MCP servers and skills for security risks")
     scan_parser.add_argument("--workspace", help="Workspace path")
-    scan_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes"], help="Only scan configs for this agent")
+    scan_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "gemini"], help="Only scan configs for this agent")
     scan_parser.add_argument("--json", action="store_true", help="Output raw JSON")
 
     # ── audit ──────────────────────────────────────────────────────────
@@ -742,20 +742,20 @@ def build_parser() -> argparse.ArgumentParser:
     # ── install-hooks ──────────────────────────────────────────────────
     install_parser = subparsers.add_parser("install-hooks", help="Install IDE hooks for real-time monitoring")
     install_parser.add_argument("--workspace", help="Workspace path")
-    install_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "all"], required=True, help="Which agent/IDE")
+    install_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "gemini", "all"], required=True, help="Which agent/IDE")
     install_parser.add_argument("--scope", choices=["project", "user"], default="project", help="Hook scope (default: project)")
     install_parser.add_argument("--mode", choices=["observe", "enforce"], default="observe", help="observe=log only, enforce=block dangerous actions")
 
     # ── uninstall-hooks ────────────────────────────────────────────────
     uninstall_parser = subparsers.add_parser("uninstall-hooks", help="Remove IDE hooks")
     uninstall_parser.add_argument("--workspace", help="Workspace path")
-    uninstall_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "all"], required=True, help="Which agent/IDE")
+    uninstall_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "gemini", "all"], required=True, help="Which agent/IDE")
     uninstall_parser.add_argument("--scope", choices=["project", "user"], default="project", help="Hook scope")
 
     # ── hook-dispatch (internal) ───────────────────────────────────────
     hook_dispatch = subparsers.add_parser("hook-dispatch", help="(internal) Called by IDE hooks")
     hook_dispatch.add_argument("--workspace", help="Workspace path")
-    hook_dispatch.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes"], required=True)
+    hook_dispatch.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "gemini"], required=True)
     hook_dispatch.add_argument("--mode", choices=["observe", "enforce"], default="observe")
 
     # ── policy ─────────────────────────────────────────────────────────
@@ -872,7 +872,7 @@ def _print_info(workspace: Path) -> None:
     # Hooks — check which agents have hooks installed
     agents_with_hooks = []
     mode = None
-    for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes"):
+    for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes", "gemini"):
         hook_path = _find_hook_config(agent_name, workspace)
         if hook_path and hook_path.exists():
             try:
@@ -921,6 +921,8 @@ def _find_hook_config(agent: str, workspace: Path) -> Path:
         return workspace / ".openclaw" / "plugins.json"
     if agent == "hermes":
         return workspace / ".hermes" / "plugins.json"
+    if agent == "gemini":
+        return workspace / ".gemini" / "settings.json"
     return workspace / ".windsurf" / "hooks.json"
 
 
@@ -967,7 +969,7 @@ def _print_dashboard() -> None:
 
         # Mode detection
         mode = ""
-        for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes"):
+        for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes", "gemini"):
             hook_path = _find_hook_config(agent_name, ws)
             if hook_path and hook_path.exists():
                 try:

--- a/warden/hooks.py
+++ b/warden/hooks.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List
 
 from warden.store import append_session_event
 
-_SUPPORTED_AGENTS = ["claude", "cursor", "windsurf", "openclaw", "hermes"]
+_SUPPORTED_AGENTS = ["claude", "cursor", "windsurf", "openclaw", "hermes", "gemini"]
 
 
 def install_hooks(*, repo_root: Path, workspace: Path, agent: str, scope: str, mode: str) -> List[Dict[str, str]]:
@@ -27,6 +27,8 @@ def install_hooks(*, repo_root: Path, workspace: Path, agent: str, scope: str, m
             config = _merge_openclaw(config, command, repo_root)
         elif current_agent == "hermes":
             config = _merge_hermes(config, command, repo_root)
+        elif current_agent == "gemini":
+            config = _merge_gemini(config, command)
         else:
             config = _merge_windsurf(config, command, workspace)
 
@@ -53,6 +55,8 @@ def uninstall_hooks(*, repo_root: Path, workspace: Path, agent: str, scope: str)
                 config, removed = _strip_openclaw(config, marker)
             elif current_agent == "hermes":
                 config, removed = _strip_hermes(config, marker)
+            elif current_agent == "gemini":
+                config, removed = _strip_gemini(config, marker)
             else:
                 config, removed = _strip_windsurf(config, marker)
             if removed:
@@ -91,6 +95,8 @@ def normalize_payload(*, agent: str, payload: Dict[str, Any], workspace: Path) -
         event = _normalize_openclaw(payload, session_id)
     elif agent == "hermes":
         event = _normalize_hermes(payload, session_id)
+    elif agent == "gemini":
+        event = _normalize_gemini(payload, session_id)
     else:
         event = _normalize_cursor(payload, session_id)
     return {"sessionId": session_id, "event": event}
@@ -124,6 +130,8 @@ def _config_path(agent: str, scope: str, workspace: Path) -> Path:
             return workspace / ".openclaw" / "plugins.json"
         if agent == "hermes":
             return workspace / ".hermes" / "plugins.json"
+        if agent == "gemini":
+            return workspace / ".gemini" / "settings.json"
         return workspace / ".windsurf" / "hooks.json"
 
     if agent == "claude":
@@ -134,6 +142,8 @@ def _config_path(agent: str, scope: str, workspace: Path) -> Path:
         return home / ".openclaw" / "config.json"
     if agent == "hermes":
         return home / ".hermes" / "config.json"
+    if agent == "gemini":
+        return home / ".gemini" / "settings.json"
     return home / ".codeium" / "windsurf" / "hooks.json"
 
 
@@ -517,6 +527,108 @@ def _scaffold_hermes_internal_hook(hooks_dir: Path, command: str) -> None:
     (hooks_dir / "HOOK.md").write_text(_HERMES_HOOK_MD, encoding="utf-8")
     js = _HERMES_HOOK_JS.replace("__WARDEN_COMMAND__", command)
     (hooks_dir / "handler.js").write_text(js, encoding="utf-8")
+
+
+def _merge_gemini(config: Dict[str, Any], command: str) -> Dict[str, Any]:
+    hooks = dict(config.get("hooks", {}))
+    tool_entry = {
+        "matcher": ".*",
+        "hooks": [{"type": "command", "command": command, "name": "prismor-warden", "timeout": 60000}],
+    }
+    agent_entry = {
+        "hooks": [{"type": "command", "command": command, "name": "prismor-warden", "timeout": 60000}],
+    }
+    hooks["BeforeTool"] = _merge_gemini_entries(hooks.get("BeforeTool", []), tool_entry, command, has_matcher=True)
+    hooks["AfterTool"] = _merge_gemini_entries(hooks.get("AfterTool", []), tool_entry, command, has_matcher=True)
+    hooks["BeforeAgent"] = _merge_gemini_entries(hooks.get("BeforeAgent", []), agent_entry, command, has_matcher=False)
+    return {**config, "hooks": hooks}
+
+
+def _strip_gemini(config: Dict[str, Any], marker: str) -> tuple[Dict[str, Any], bool]:
+    hooks = dict(config.get("hooks", {}))
+    removed = False
+    for event_name in list(hooks.keys()):
+        entries = hooks[event_name]
+        if not isinstance(entries, list):
+            continue
+        cleaned = []
+        for entry in entries:
+            inner_hooks = entry.get("hooks", [])
+            filtered = [h for h in inner_hooks if marker not in h.get("command", "")]
+            if len(filtered) < len(inner_hooks):
+                removed = True
+            if filtered:
+                cleaned.append({**entry, "hooks": filtered})
+        hooks[event_name] = cleaned
+    return {**config, "hooks": hooks}, removed
+
+
+def _merge_gemini_entries(
+    entries: List[Dict[str, Any]],
+    new_entry: Dict[str, Any],
+    command: str,
+    *,
+    has_matcher: bool,
+) -> List[Dict[str, Any]]:
+    next_entries = list(entries)
+    if has_matcher:
+        matcher = new_entry["matcher"]
+        existing = next((e for e in next_entries if e.get("matcher") == matcher), None)
+        if existing is None:
+            next_entries.append(new_entry)
+            return next_entries
+        existing_commands = {hook.get("command") for hook in existing.get("hooks", [])}
+        for hook in new_entry["hooks"]:
+            if hook.get("command") not in existing_commands:
+                existing.setdefault("hooks", []).append(hook)
+        return next_entries
+
+    for entry in next_entries:
+        existing_commands = {hook.get("command") for hook in entry.get("hooks", [])}
+        if command in existing_commands:
+            return next_entries
+    next_entries.append(new_entry)
+    return next_entries
+
+
+def _normalize_gemini(payload: Dict[str, Any], session_id: str) -> Dict[str, Any]:
+    hook_event = payload.get("hook_event_name", "unknown")
+    tool_name = payload.get("tool_name", "")
+    tool_input = payload.get("tool_input", {}) or {}
+    base = {
+        "ts": payload.get("timestamp"),
+        "session_id": session_id,
+        "agent": "gemini",
+        "agent_event": hook_event,
+        "metadata": {"cwd": payload.get("cwd"), "tool_name": tool_name, "raw": payload},
+    }
+    if hook_event == "BeforeAgent":
+        return {**base, "type": "prompt", "prompt": payload.get("prompt", "")}
+    if hook_event == "AfterAgent":
+        return {**base, "type": "tool_result", "response": payload.get("prompt_response", "")}
+    if tool_name in {"run_shell_command", "shell", "bash"}:
+        return {**base, "type": "shell", "command": tool_input.get("command", "")}
+    if tool_name in {"read_file", "read_many_files"}:
+        return {
+            **base,
+            "type": "file_read",
+            "path": tool_input.get("absolute_path") or tool_input.get("file_path") or tool_input.get("path", ""),
+        }
+    if tool_name in {"write_file", "replace", "edit"}:
+        return {
+            **base,
+            "type": "file_write",
+            "path": tool_input.get("file_path") or tool_input.get("path", ""),
+            "content": tool_input.get("content") or tool_input.get("new_string", ""),
+        }
+    if tool_name in {"web_fetch", "web_search", "google_web_search"}:
+        return {
+            **base,
+            "type": "network",
+            "url": tool_input.get("url") or tool_input.get("query", ""),
+            "response": (payload.get("tool_response") or {}).get("llmContent", ""),
+        }
+    return {**base, "type": "tool_result", "response": json.dumps(payload)}
 
 
 def _merge_claude_entries(entries: List[Dict[str, Any]], new_entry: Dict[str, Any]) -> List[Dict[str, Any]]:

--- a/warden/scanner.py
+++ b/warden/scanner.py
@@ -1,8 +1,9 @@
 """Skill / MCP server scanner for Prismor Warden.
 
 Discovers MCP server and skill configurations across supported agents
-(Claude Code, Cursor, Windsurf, OpenClaw, Hermes), synthesizes skill_manifest
-events from each entry, and evaluates them through the PolicyEngine.
+(Claude Code, Cursor, Windsurf, OpenClaw, Hermes, Gemini CLI), synthesizes
+skill_manifest events from each entry, and evaluates them through the
+PolicyEngine.
 
 Usage (from CLI):
     warden scan                   # scan all discovered configs
@@ -74,12 +75,22 @@ def _hermes_configs() -> List[Path]:
     return [p for p in candidates if p.exists()]
 
 
+def _gemini_configs() -> List[Path]:
+    home = Path.home()
+    candidates = [
+        home / ".gemini" / "settings.json",
+        Path.cwd() / ".gemini" / "settings.json",
+    ]
+    return [p for p in candidates if p.exists()]
+
+
 _AGENT_DISCOVERERS = {
     "claude": _claude_configs,
     "cursor": _cursor_configs,
     "windsurf": _windsurf_configs,
     "openclaw": _openclaw_configs,
     "hermes": _hermes_configs,
+    "gemini": _gemini_configs,
 }
 
 

--- a/warden/sweep.py
+++ b/warden/sweep.py
@@ -30,6 +30,7 @@ TOOL_DIRS: dict[str, Path] = {
     "antigravity": Path.home() / ".antigravity",
     "cursor": Path.home() / ".config" / "Cursor",
     "claude": Path.home() / ".claude",
+    "gemini": Path.home() / ".gemini",
 }
 
 # Config files that should NEVER be redacted (they hold keys the tools need)


### PR DESCRIPTION
## Summary

First net-new hook adapter landing on the AGENT_INTEGRATIONS.md roadmap. Gemini CLI uses the same stdin-JSON + exit-2 contract as Claude Code, so the adapter slots into the existing dispatcher with no core changes.

- **hooks:** `_merge_gemini` writes `BeforeTool` / `AfterTool` (matcher `.*`) and `BeforeAgent` into `settings.json`'s `hooks` block; merges idempotently alongside user-defined hooks.
- **normalizer:** `_normalize_gemini` maps `run_shell_command` → shell, `read_file`/`read_many_files` → file_read, `write_file`/`replace` → file_write, `web_fetch`/`google_web_search` → network.
- **uninstall:** `_strip_gemini` removes entries by the `warden/cli.py` marker, leaving co-habiting user hooks intact.
- **sweep:** `~/.gemini/` added to `TOOL_DIRS`.
- **skill scan:** `_gemini_configs` discovers user + project `settings.json` so `warden scan` picks up `mcpServers` entries.
- **CLI:** `gemini` added to all 4 `--agent` choice lists and the 2 agent-enumeration loops.
- **Docs:** `AGENT_INTEGRATIONS.md` moves Gemini from roadmap to supported tier.

## Blocking semantics

Gemini's contract: exit 2 with stderr message → "System Block" (sends stderr to the agent as a tool error; for agent events aborts the turn). Empty stdout on exit 0 → allow. This is identical to Claude Code's dispatcher convention, so Warden's existing `raise SystemExit(2)` path works unchanged.

## Smoke test (local)

\`\`\`
install path: /tmp/.../.gemini/settings.json
events registered: ['BeforeTool', 'AfterTool', 'BeforeAgent']
normalized type: shell command: ls -la agent: gemini
prompt normalized: prompt hello world
write normalized: file_write /tmp/x
uninstall removed: True residual hook entries: 0
\`\`\`

## Test plan

- [ ] Install `warden install-hooks --agent gemini --mode enforce` in a scratch workspace and verify `.gemini/settings.json` contains prismor-warden entries for BeforeTool/AfterTool/BeforeAgent.
- [ ] Run Gemini CLI with a benign command — confirm Warden receives the BeforeTool payload and logs the session event.
- [ ] Run Gemini CLI with a blocked pattern (e.g. a shell command matching a destructive rule) in enforce mode — confirm exit 2 → System Block with the rejection reason.
- [ ] Uninstall and verify hooks entries are removed without touching other users' hooks.
- [ ] `warden sweep` and `warden scan` discover `~/.gemini/` content.

## Not in this PR

- `BeforeModel`, `BeforeToolSelection`, `AfterModel`, `SessionStart`, `SessionEnd`, `Notification`, `PreCompress` events — not wired by default. Can be added later if useful.
- Codex / Kiro / Copilot CLI / OpenCode adapters — separate PRs.