### PR TITLE
Add GitHub Copilot CLI hook adapter

### DIFF
--- a/AGENT_INTEGRATIONS.md
+++ b/AGENT_INTEGRATIONS.md
@@ -20,8 +20,7 @@ _Last updated: 2026-04-21._
 | OpenCode | 🟡 roadmap | — | — | JS plugin `tool.execute.before` |
 | Kiro | 🟡 roadmap | — | — | `preToolUse` hooks (exit-2 blocks) |
 | Factory Droid | 🟡 roadmap | — | — | `PreToolUse` plugin (`permissionDecision`) |
-| GitHub Copilot CLI | 🟡 roadmap | — | — | `permissionRequest` hook |
-| VS Code Copilot Chat | 🟡 roadmap (preview) | — | — | `PreToolUse` hook |
+| GitHub Copilot CLI | ✅ | — | — | `.github/copilot/hooks.json` |
 | Google Antigravity | — | ✅ | — | no hooks — rules + interactive permissions |
 | Aider | — | — | — | `CONVENTIONS.md` — no hooks |
 | Trae / Trae CN | — | — | — | `.trae/rules/` — no hooks (MCP is the only dynamic surface) |
@@ -70,6 +69,15 @@ _Last updated: 2026-04-21._
 - **Session ingest:** offline analysis of `~/.hermes/sessions/*.jsonl` via `warden ingest --input <file> --agent hermes`.
 - **Code:** `warden/hooks.py` `_merge_hermes()`, `_normalize_hermes()`.
 
+### GitHub Copilot CLI
+
+- **Config:** `~/.copilot/hooks.json` (user) or `.github/copilot/hooks.json` (project).
+- **Events hooked:** `PreToolUse`, `PostToolUse`, `UserPromptSubmitted`.
+- **Blocking:** hook emits `{"permissionDecision": "deny", "permissionDecisionReason": "..."}` on stdout. Exit-2 convention is not used — Copilot reads the JSON response instead.
+- **Static layer:** `--allow-tool` / `--deny-tool` / `--allow-all-tools` CLI flags apply before the hook fires (deny beats allow). Useful as defense-in-depth.
+- **Payload note:** `toolArgs` arrives as a JSON-encoded string; `_normalize_copilot()` parses it before evaluation.
+- **Code:** `warden/hooks.py` `_merge_copilot()`, `_strip_copilot()`, `_normalize_copilot()`.
+
 ---
 
 ## Roadmap — hook adapters planned
@@ -116,22 +124,6 @@ Each agent below exposes a blocking pre-tool hook. An adapter requires (1) confi
 - **Hooks:** `PreToolUse`, `PostToolUse` (Claude-Code-compatible JSON contract). Matchers like `Write|Edit` shown in plugin examples.
 - **Blocking:** return `{permissionDecision: "deny", reason}`; `updatedInput` supports input rewriting before execution.
 - **Adapter work:** the JSON-response contract differs from Claude's exit-2 convention — dispatcher needs to emit a response object, not just an exit code. Otherwise reuse normalizer.
-
-### GitHub Copilot CLI
-
-- **Config:** `~/.copilot/` (hooks in the Copilot CLI config file).
-- **Hooks:** `permissionRequest` (fires after static allow/deny rules miss), plus lifecycle hooks (`PreToolUse`, `PostToolUse`, etc.).
-- **Blocking:** return `permissionDecision: "deny"`. Only `"deny"` is currently processed — `"allow"` and `"ask"` are no-ops.
-- **Static layer:** `--allow-tool`, `--deny-tool`, `--allow-all-tools` flags apply before the hook (deny beats allow) — useful as defense-in-depth, not a substitute for the hook.
-- **Adapter work:** hook adapter plus an optional `warden export --copilot-cli` subcommand that emits a stable `--deny-tool` list from the policy.
-
-### VS Code Copilot Chat — preview
-
-- **Config:** `.vscode/` (workspace) + user `settings.json`.
-- **Hooks:** `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `Stop`.
-- **Blocking:** return `hookSpecificOutput.permissionDecision: "allow"|"deny"|"ask"` — most-restrictive wins; `continue: false` halts the turn.
-- **Caveat:** preview feature — recheck GA status and payload stability before shipping. Distinct from Copilot CLI.
-- **Adapter work:** similar to Claude adapter shape. Payload TBD against GA.
 
 ---
 

--- a/warden/cli.py
+++ b/warden/cli.py
@@ -468,10 +468,17 @@ def main() -> None:
         current_findings = _current_engine.evaluate(event, len(events) - 1, session_id=normalized["sessionId"])
         blocking = should_block(current_findings, event, block_categories=set(result.get("blockCategories", [])))
         if args.mode == "enforce" and blocking is not None:
-            sys.stderr.write(f"Prismor Warden blocked this action: [{blocking['severity']}] {blocking['title']}\n")
-            if blocking.get("evidence"):
-                sys.stderr.write(f"{blocking['evidence']}\n")
-            raise SystemExit(2)
+            if args.agent == "copilot":
+                # Copilot CLI reads permissionDecision from stdout; exit 2 is ignored.
+                reason = f"[{blocking['severity']}] {blocking['title']}"
+                if blocking.get("evidence"):
+                    reason += f"\n{blocking['evidence']}"
+                sys.stdout.write(json.dumps({"permissionDecision": "deny", "permissionDecisionReason": reason}) + "\n")
+            else:
+                sys.stderr.write(f"Prismor Warden blocked this action: [{blocking['severity']}] {blocking['title']}\n")
+                if blocking.get("evidence"):
+                    sys.stderr.write(f"{blocking['evidence']}\n")
+                raise SystemExit(2)
         elif args.mode == "observe" and blocking is not None:
             # Show warnings in observe mode so humans/agents see feedback.
             sys.stderr.write(_color(f"[warden] ", _YELLOW) + f"[{blocking['severity']}] {blocking['title']}\n")
@@ -698,7 +705,7 @@ def build_parser() -> argparse.ArgumentParser:
     # ── scan ──────────────────────────────────────────────────────────
     scan_parser = subparsers.add_parser("scan", help="Scan all MCP servers and skills for security risks")
     scan_parser.add_argument("--workspace", help="Workspace path")
-    scan_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes"], help="Only scan configs for this agent")
+    scan_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "copilot"], help="Only scan configs for this agent")
     scan_parser.add_argument("--json", action="store_true", help="Output raw JSON")
 
     # ── audit ──────────────────────────────────────────────────────────
@@ -742,20 +749,20 @@ def build_parser() -> argparse.ArgumentParser:
     # ── install-hooks ──────────────────────────────────────────────────
     install_parser = subparsers.add_parser("install-hooks", help="Install IDE hooks for real-time monitoring")
     install_parser.add_argument("--workspace", help="Workspace path")
-    install_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "all"], required=True, help="Which agent/IDE")
+    install_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "copilot", "all"], required=True, help="Which agent/IDE")
     install_parser.add_argument("--scope", choices=["project", "user"], default="project", help="Hook scope (default: project)")
     install_parser.add_argument("--mode", choices=["observe", "enforce"], default="observe", help="observe=log only, enforce=block dangerous actions")
 
     # ── uninstall-hooks ────────────────────────────────────────────────
     uninstall_parser = subparsers.add_parser("uninstall-hooks", help="Remove IDE hooks")
     uninstall_parser.add_argument("--workspace", help="Workspace path")
-    uninstall_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "all"], required=True, help="Which agent/IDE")
+    uninstall_parser.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "copilot", "all"], required=True, help="Which agent/IDE")
     uninstall_parser.add_argument("--scope", choices=["project", "user"], default="project", help="Hook scope")
 
     # ── hook-dispatch (internal) ───────────────────────────────────────
     hook_dispatch = subparsers.add_parser("hook-dispatch", help="(internal) Called by IDE hooks")
     hook_dispatch.add_argument("--workspace", help="Workspace path")
-    hook_dispatch.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes"], required=True)
+    hook_dispatch.add_argument("--agent", choices=["claude", "cursor", "windsurf", "openclaw", "hermes", "copilot"], required=True)
     hook_dispatch.add_argument("--mode", choices=["observe", "enforce"], default="observe")
 
     # ── policy ─────────────────────────────────────────────────────────
@@ -872,7 +879,7 @@ def _print_info(workspace: Path) -> None:
     # Hooks — check which agents have hooks installed
     agents_with_hooks = []
     mode = None
-    for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes"):
+    for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes", "copilot"):
         hook_path = _find_hook_config(agent_name, workspace)
         if hook_path and hook_path.exists():
             try:
@@ -921,6 +928,8 @@ def _find_hook_config(agent: str, workspace: Path) -> Path:
         return workspace / ".openclaw" / "plugins.json"
     if agent == "hermes":
         return workspace / ".hermes" / "plugins.json"
+    if agent == "copilot":
+        return workspace / ".github" / "copilot" / "hooks.json"
     return workspace / ".windsurf" / "hooks.json"
 
 
@@ -967,7 +976,7 @@ def _print_dashboard() -> None:
 
         # Mode detection
         mode = ""
-        for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes"):
+        for agent_name in ("claude", "cursor", "windsurf", "openclaw", "hermes", "copilot"):
             hook_path = _find_hook_config(agent_name, ws)
             if hook_path and hook_path.exists():
                 try:

--- a/warden/hooks.py
+++ b/warden/hooks.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List
 
 from warden.store import append_session_event
 
-_SUPPORTED_AGENTS = ["claude", "cursor", "windsurf", "openclaw", "hermes"]
+_SUPPORTED_AGENTS = ["claude", "cursor", "windsurf", "openclaw", "hermes", "copilot"]
 
 
 def install_hooks(*, repo_root: Path, workspace: Path, agent: str, scope: str, mode: str) -> List[Dict[str, str]]:
@@ -27,6 +27,8 @@ def install_hooks(*, repo_root: Path, workspace: Path, agent: str, scope: str, m
             config = _merge_openclaw(config, command, repo_root)
         elif current_agent == "hermes":
             config = _merge_hermes(config, command, repo_root)
+        elif current_agent == "copilot":
+            config = _merge_copilot(config, command)
         else:
             config = _merge_windsurf(config, command, workspace)
 
@@ -53,6 +55,8 @@ def uninstall_hooks(*, repo_root: Path, workspace: Path, agent: str, scope: str)
                 config, removed = _strip_openclaw(config, marker)
             elif current_agent == "hermes":
                 config, removed = _strip_hermes(config, marker)
+            elif current_agent == "copilot":
+                config, removed = _strip_copilot(config, marker)
             else:
                 config, removed = _strip_windsurf(config, marker)
             if removed:
@@ -91,6 +95,8 @@ def normalize_payload(*, agent: str, payload: Dict[str, Any], workspace: Path) -
         event = _normalize_openclaw(payload, session_id)
     elif agent == "hermes":
         event = _normalize_hermes(payload, session_id)
+    elif agent == "copilot":
+        event = _normalize_copilot(payload, session_id)
     else:
         event = _normalize_cursor(payload, session_id)
     return {"sessionId": session_id, "event": event}
@@ -124,6 +130,8 @@ def _config_path(agent: str, scope: str, workspace: Path) -> Path:
             return workspace / ".openclaw" / "plugins.json"
         if agent == "hermes":
             return workspace / ".hermes" / "plugins.json"
+        if agent == "copilot":
+            return workspace / ".github" / "copilot" / "hooks.json"
         return workspace / ".windsurf" / "hooks.json"
 
     if agent == "claude":
@@ -134,6 +142,8 @@ def _config_path(agent: str, scope: str, workspace: Path) -> Path:
         return home / ".openclaw" / "config.json"
     if agent == "hermes":
         return home / ".hermes" / "config.json"
+    if agent == "copilot":
+        return home / ".copilot" / "hooks.json"
     return home / ".codeium" / "windsurf" / "hooks.json"
 
 
@@ -517,6 +527,59 @@ def _scaffold_hermes_internal_hook(hooks_dir: Path, command: str) -> None:
     (hooks_dir / "HOOK.md").write_text(_HERMES_HOOK_MD, encoding="utf-8")
     js = _HERMES_HOOK_JS.replace("__WARDEN_COMMAND__", command)
     (hooks_dir / "handler.js").write_text(js, encoding="utf-8")
+
+
+def _merge_copilot(config: Dict[str, Any], command: str) -> Dict[str, Any]:
+    hooks = dict(config.get("hooks", {}))
+    for event_name in ["PreToolUse", "PostToolUse", "UserPromptSubmitted"]:
+        hooks[event_name] = _merge_simple_command_entries(hooks.get(event_name, []), command)
+    return {**config, "version": config.get("version", 1), "hooks": hooks}
+
+
+def _strip_copilot(config: Dict[str, Any], marker: str) -> tuple[Dict[str, Any], bool]:
+    hooks = dict(config.get("hooks", {}))
+    removed = False
+    for event_name in list(hooks.keys()):
+        entries = hooks[event_name]
+        if not isinstance(entries, list):
+            continue
+        filtered = [e for e in entries if marker not in e.get("command", "")]
+        if len(filtered) < len(entries):
+            removed = True
+        hooks[event_name] = filtered
+    return {**config, "hooks": hooks}, removed
+
+
+def _normalize_copilot(payload: Dict[str, Any], session_id: str) -> Dict[str, Any]:
+    hook_event = payload.get("hookEventName") or payload.get("hook_event_name") or "unknown"
+    tool_name = payload.get("toolName") or payload.get("tool_name") or ""
+    # Copilot sends toolArgs as a JSON-encoded string; parse it.
+    tool_args_raw = payload.get("toolArgs") or payload.get("tool_args") or "{}"
+    if isinstance(tool_args_raw, str):
+        try:
+            tool_args: Dict[str, Any] = json.loads(tool_args_raw)
+        except (json.JSONDecodeError, ValueError):
+            tool_args = {"raw": tool_args_raw}
+    else:
+        tool_args = tool_args_raw
+    base = {
+        "ts": payload.get("timestamp"),
+        "session_id": session_id,
+        "agent": "copilot",
+        "agent_event": hook_event,
+        "metadata": {"cwd": payload.get("cwd"), "tool_name": tool_name, "raw": payload},
+    }
+    if hook_event == "UserPromptSubmitted":
+        return {**base, "type": "prompt", "prompt": payload.get("prompt") or tool_args.get("prompt", "")}
+    if tool_name in {"ShellCommand", "run_shell_command", "Bash"}:
+        return {**base, "type": "shell", "command": tool_args.get("command") or tool_args.get("cmd", "")}
+    if tool_name in {"ReadFile", "read_file", "Read"}:
+        return {**base, "type": "file_read", "path": tool_args.get("path") or tool_args.get("filePath", "")}
+    if tool_name in {"WriteFile", "write_file", "EditFile", "Write", "Edit"}:
+        return {**base, "type": "file_write", "path": tool_args.get("path") or tool_args.get("filePath", ""), "content": tool_args.get("content", "")}
+    if tool_name in {"WebFetch", "web_fetch", "WebSearch"}:
+        return {**base, "type": "network", "url": tool_args.get("url", "")}
+    return {**base, "type": "tool_result", "response": json.dumps(payload)}
 
 
 def _merge_claude_entries(entries: List[Dict[str, Any]], new_entry: Dict[str, Any]) -> List[Dict[str, Any]]:


### PR DESCRIPTION
## Summary

- Full Warden hook adapter for GitHub Copilot CLI — `_merge_copilot`, `_strip_copilot`, `_normalize_copilot` in `warden/hooks.py`
- Config paths: `.github/copilot/hooks.json` (project) and `~/.copilot/hooks.json` (user); hooks `PreToolUse`, `PostToolUse`, `UserPromptSubmitted`
- Key protocol difference from all other adapters: Copilot reads `{"permissionDecision": "deny", "permissionDecisionReason": "..."}` on stdout instead of exit 2 — `hook-dispatch` in `cli.py` handles this when `--agent copilot` is set
- `toolArgs` in Copilot's payload is a JSON-encoded string; `_normalize_copilot()` parses it before evaluation
- Registered in `_SUPPORTED_AGENTS`, all four `cli.py` choice lists, both agent enumeration loops, and `_find_hook_config`
- `AGENT_INTEGRATIONS.md`: Copilot CLI promoted from roadmap → supported; VS Code Copilot Chat removed (preview, deferred)

## Test plan

- [ ] `python3 -m pytest tests/ -q` — 198 pass, 5 pre-existing failures, no new failures
- [ ] Smoke: `_merge_copilot`, `_strip_copilot`, `normalize_payload(agent="copilot", ...)` all verified with inline assertions
- [ ] `warden install-hooks --agent copilot --scope project` writes `.github/copilot/hooks.json`
- [ ] `warden install-hooks --agent all` includes copilot without error
- [ ] `warden uninstall-hooks --agent copilot` removes Warden entries cleanly
- [ ] hook-dispatch with enforce mode emits JSON on stdout (not exit 2) for a blocked event