### PR TITLE
Close audit gaps in detection, workspace resolution, and lifecycle

### DIFF
--- a/scripts/upgrade_feed.py
+++ b/scripts/upgrade_feed.py
@@ -1,8 +1,25 @@
 #!/usr/bin/env python3
-"""Retroactively upgrade existing feed advisories with better titles, types, actions, and deduplicated references."""
+"""Retroactively upgrade existing feed advisories with better titles, types,
+actions, and deduplicated references.
+
+MAINTAINER TOOL — NOT for end users. Re-writing the feed invalidates the
+Ed25519 signature and breaks `warden audit`. Run this only in CI where
+PRISMOR_SIGNING_PRIVATE_KEY is available so the feed is re-signed in the
+same step.
+
+Behaviour:
+  - No changes needed           → exit 0 without touching the file (signature
+                                  stays valid).
+  - Changes applied in CI       → feed is re-signed automatically via
+                                  pipeline/sign_feed.sh.
+  - Changes applied locally     → warn loudly that the signature is now
+                                  stale; `warden audit` will fail until the
+                                  user re-clones or a signed feed is pulled.
+"""
 
 import json
 import os
+import subprocess
 import sys
 from datetime import datetime, timezone
 
@@ -15,7 +32,9 @@ from pipeline.fetch_nvd_intel import (
     map_cwe_to_type,
 )
 
-FEED_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "advisories", "immunity-feed.json")
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FEED_PATH = os.path.join(REPO_ROOT, "advisories", "immunity-feed.json")
+SIGN_SCRIPT = os.path.join(REPO_ROOT, "pipeline", "sign_feed.sh")
 
 
 def upgrade_advisory(adv):
@@ -56,7 +75,8 @@ def upgrade_advisory(adv):
 
 def main():
     with open(FEED_PATH, "r") as f:
-        feed = json.load(f)
+        original_text = f.read()
+    feed = json.loads(original_text)
 
     advisories = feed.get("advisories", [])
     total = len(advisories)
@@ -77,6 +97,13 @@ def main():
         if len(adv.get("references", [])) < old_ref_count:
             stats["refs_deduped"] += 1
 
+    changes = sum(stats.values())
+    if changes == 0:
+        print("Feed already up to date — no changes, signature preserved.", file=sys.stderr)
+        return
+
+    # Only bump 'updated' when we actually change something; prevents
+    # spurious signature invalidation on no-op runs.
     feed["updated"] = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
     with open(FEED_PATH, "w") as f:
@@ -96,6 +123,29 @@ def main():
     print(f"\nType distribution:", file=sys.stderr)
     for t, c in type_counts.most_common():
         print(f"  {t}: {c}", file=sys.stderr)
+
+    # Re-sign or warn loudly — the feed has changed so the shipped
+    # signature no longer matches.
+    if os.environ.get("PRISMOR_SIGNING_PRIVATE_KEY") and os.path.exists(SIGN_SCRIPT):
+        print("\nRe-signing feed (PRISMOR_SIGNING_PRIVATE_KEY detected)...", file=sys.stderr)
+        result = subprocess.run(
+            ["bash", SIGN_SCRIPT],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            print(f"ERROR: sign_feed.sh failed:\n{result.stderr}", file=sys.stderr)
+            sys.exit(1)
+        print("Feed re-signed successfully.", file=sys.stderr)
+    else:
+        print(
+            "\nWARNING: feed content changed but was NOT re-signed.\n"
+            "         `warden audit` will report a signature mismatch until a\n"
+            "         freshly signed feed is pulled (set PRISMOR_SIGNING_PRIVATE_KEY\n"
+            "         and re-run, or restore the original feed with `git checkout`).",
+            file=sys.stderr,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,7 +92,10 @@ class TestCliAnalyze(unittest.TestCase):
         self.assertEqual(data["summary"]["riskScore"], 100)
 
     def test_analyze_missing_input(self):
-        r = run_cli("analyze")
+        # Use an empty workspace so no stored session is available.
+        import tempfile
+        with tempfile.TemporaryDirectory() as empty_ws:
+            r = run_cli("analyze", "--workspace", empty_ws)
         self.assertNotEqual(r.returncode, 0)
 
 

--- a/tests/test_policy_engine.py
+++ b/tests/test_policy_engine.py
@@ -118,7 +118,7 @@ class TestPolicyEngineDefaults(unittest.TestCase):
         self.assertEqual(self.engine.evaluate({}, 0), [])
 
     def test_session_id_prefix(self):
-        event = {"type": "shell", "command": "sudo rm file"}
+        event = {"type": "shell", "command": "rm -rf /"}
         findings = self.engine.evaluate(event, 0, session_id="sess-1")
         self.assertTrue(findings[0]["id"].startswith("sess-1:"))
 

--- a/warden/cli.py
+++ b/warden/cli.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import shutil
 import sys
@@ -112,7 +113,25 @@ def main() -> None:
         return
 
     repo_root = Path(__file__).resolve().parent.parent
-    workspace = Path(args.workspace).resolve() if getattr(args, "workspace", None) else infer_default_workspace(Path.cwd())
+
+    # Resolve workspace: explicit --workspace flag (at any position) wins,
+    # then PRISMOR_WARDEN_WORKSPACE env var, then inferred from cwd.
+    # argparse subparsers that also declare --workspace clobber the top-level
+    # value with None when the flag isn't repeated on the subcommand — so we
+    # fall back to a manual scan of argv to recover the original value.
+    ws_value = getattr(args, "workspace", None)
+    if not ws_value:
+        argv = sys.argv[1:]
+        for i, tok in enumerate(argv):
+            if tok == "--workspace" and i + 1 < len(argv):
+                ws_value = argv[i + 1]
+                break
+            if tok.startswith("--workspace="):
+                ws_value = tok.split("=", 1)[1]
+                break
+    if not ws_value:
+        ws_value = os.environ.get("PRISMOR_WARDEN_WORKSPACE")
+    workspace = Path(ws_value).resolve() if ws_value else infer_default_workspace(Path.cwd())
 
     # ── dashboard: global overview ───────────────────────────────────────
     if args.command == "dashboard":
@@ -144,7 +163,11 @@ def main() -> None:
             color = _RED if sev == "CRITICAL" else _YELLOW if sev == "HIGH" else _DIM
             action_label = f.get("action", "warn").upper()
             print(_color(f"[{sev}]", color) + f" {f['title']}  " + _color(f"({action_label})", color))
-            print(f"  rule: {f.get('ruleId', '?')}  evidence: {f['evidence']}")
+            # _resolve_path returns "{original}\n{resolved}" for symlink-aware
+            # matching — keep only the user-supplied value in CLI output so
+            # the extra line doesn't break downstream parsers.
+            evidence = str(f.get("evidence", "")).split("\n", 1)[0]
+            print(f"  rule: {f.get('ruleId', '?')}  evidence: {evidence}")
 
         # Exit 2 if any finding has action=block, 1 for warn-only, 0 for log-only.
         if any(f.get("action") == "block" for f in findings):
@@ -406,6 +429,9 @@ def main() -> None:
 
     # ── analyze ────────────────────────────────────────────────────────
     if args.command == "analyze":
+        # Accept `analyze <file>` as shorthand for `analyze --input <file>`.
+        if not args.input and getattr(args, "file", None):
+            args.input = args.file
         # If no input specified, use most recent session
         if args.input:
             events = parse_jsonl(read_text(args.input))
@@ -424,7 +450,7 @@ def main() -> None:
 
         result = analyze_events(events, repo_root=repo_root, workspace=workspace)
         if getattr(args, "sarif", False):
-            print(json.dumps(format_sarif(result), indent=2))
+            print(json.dumps(format_sarif(result, workspace=workspace), indent=2))
         else:
             emit(result, as_json=args.json, formatter=format_analysis)
         return
@@ -470,9 +496,13 @@ def main() -> None:
         return
 
     if args.command == "session":
-        session = get_session(workspace, args.session_id)
+        # Accept `session <id>` as shorthand for `session --session-id <id>`.
+        session_id = args.session_id or getattr(args, "session_id_pos", None)
+        if not session_id:
+            raise SystemExit("session: --session-id or a positional session id is required")
+        session = get_session(workspace, session_id)
         if session is None:
-            raise SystemExit(f"Session not found: {args.session_id}")
+            raise SystemExit(f"Session not found: {session_id}")
         emit(session, as_json=args.json, formatter=format_session)
         return
 
@@ -556,15 +586,30 @@ def main() -> None:
             ok as sweep_ok, warn as sweep_warn, err as sweep_err,
         )
 
+        def _need_passphrase(confirm: bool = False) -> str:
+            """Wrap _prompt_passphrase with a clean error when no TTY is
+            available. Prevents an unhandled RuntimeError traceback in
+            CI / hook contexts."""
+            try:
+                return _prompt_passphrase(confirm=confirm)
+            except RuntimeError as exc:
+                sys.stderr.write(
+                    _color("[sweep] ", _RED)
+                    + f"{exc}\n"
+                    + "        Set the PRISMOR_SWEEP_PASS environment variable\n"
+                    + "        (non-interactive) or re-run from a terminal.\n"
+                )
+                raise SystemExit(1)
+
         # Show vault contents
         if getattr(args, "show_vault", False):
-            passphrase = _prompt_passphrase()
+            passphrase = _need_passphrase()
             show_vault(passphrase)
             return
 
         # Restore mode
         if getattr(args, "restore", False):
-            passphrase = _prompt_passphrase()
+            passphrase = _need_passphrase()
             restore(passphrase, target_file=getattr(args, "file", None), all_entries=getattr(args, "all", False))
             return
 
@@ -581,9 +626,9 @@ def main() -> None:
         if getattr(args, "clean", False):
             sweep_info("Passphrase required to authorize deletion and update vault.")
             if _vault_exists():
-                passphrase = _prompt_passphrase()
+                passphrase = _need_passphrase()
             else:
-                passphrase = _prompt_passphrase(confirm=True)
+                passphrase = _need_passphrase(confirm=True)
             clean(findings, passphrase)
             return
 
@@ -599,12 +644,12 @@ def main() -> None:
                 report_findings(findings)
                 print()
                 sweep_info("Passphrase required to update the vault.")
-                passphrase = _prompt_passphrase()
+                passphrase = _need_passphrase()
             else:
                 report_findings(findings)
                 print()
                 sweep_info("First-time vault setup — creating encrypted vault for secret recovery.")
-                passphrase = _prompt_passphrase(confirm=True)
+                passphrase = _need_passphrase(confirm=True)
 
             count = redact(findings, passphrase, purge=purge)
             if count:
@@ -789,6 +834,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     # ── analyze ────────────────────────────────────────────────────────
     analyze = subparsers.add_parser("analyze", help="Analyze a session (or current session if no --input)")
+    analyze.add_argument("file", nargs="?", help="Path to JSONL session file (same as --input). If omitted, analyzes most recent session")
     analyze.add_argument("--input", help="Path to JSONL session file (or - for stdin). If omitted, analyzes most recent session")
     analyze.add_argument("--workspace", help="Workspace path")
     analyze.add_argument("--json", action="store_true", help="Output raw JSON")
@@ -811,8 +857,9 @@ def build_parser() -> argparse.ArgumentParser:
 
     # ── session ────────────────────────────────────────────────────────
     session_parser = subparsers.add_parser("session", help="Show a specific session")
+    session_parser.add_argument("session_id_pos", nargs="?", help="Session ID to view (same as --session-id)")
     session_parser.add_argument("--workspace", help="Workspace path")
-    session_parser.add_argument("--session-id", required=True, help="Session ID to view")
+    session_parser.add_argument("--session-id", help="Session ID to view")
     session_parser.add_argument("--json", action="store_true", help="Output raw JSON")
 
     # ── install-hooks ──────────────────────────────────────────────────
@@ -1348,28 +1395,61 @@ def _policy_edit(workspace: Path) -> None:
 
 # ── SARIF output ────────────────────────────────────────────────────────
 
-def format_sarif(result: Dict[str, Any]) -> Dict[str, Any]:
-    """Format analysis results as SARIF 2.1.0 for GitHub Code Scanning."""
-    rules_seen: Dict[str, int] = {}
-    sarif_rules: List[Dict[str, Any]] = []
-    sarif_results: List[Dict[str, Any]] = []
+def format_sarif(
+    result: Dict[str, Any],
+    workspace: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Format analysis results as SARIF 2.1.0 for GitHub Code Scanning.
 
-    for finding in result.get("findings", []):
-        category = finding.get("category", "unknown")
-        if category not in rules_seen:
-            rules_seen[category] = len(sarif_rules)
+    Populates rules[] from the full policy (not just triggered rules) so
+    GitHub Code Scanning, VS Code SARIF viewer, and other consumers have
+    complete rule metadata for severity, title, and category.
+    """
+    # Build rules[] from the loaded policy — gives consumers full context
+    # even for rules that didn't trigger during this run.
+    rule_index: Dict[str, int] = {}
+    sarif_rules: List[Dict[str, Any]] = []
+    try:
+        from warden.policy_engine import PolicyEngine
+        engine = PolicyEngine(workspace=workspace)
+        for rule in engine.rules:
+            rule_index[rule.id] = len(sarif_rules)
             sarif_rules.append({
-                "id": category,
-                "name": category.replace("_", " ").title(),
-                "shortDescription": {"text": finding.get("title", category)},
+                "id": rule.id,
+                "name": rule.id.replace("-", " ").replace("_", " ").title(),
+                "shortDescription": {"text": rule.title},
+                "fullDescription": {"text": f"{rule.title} (category: {rule.category})"},
+                "defaultConfiguration": {"level": _sarif_level(rule.severity)},
+                "properties": {
+                    "category": rule.category,
+                    "severity": rule.severity,
+                    "action": rule.action,
+                },
+                "helpUri": "https://github.com/PrismorSec/prismor/blob/main/docs/warden.md",
+            })
+    except Exception:
+        # Policy engine may be unavailable in some test environments.
+        pass
+
+    sarif_results: List[Dict[str, Any]] = []
+    for finding in result.get("findings", []):
+        rule_id = finding.get("ruleId") or finding.get("category", "unknown")
+        # Fallback: synthesize a rule descriptor if a finding references a
+        # rule that isn't in the policy (e.g. dynamic egress-allowlist rule).
+        if rule_id not in rule_index:
+            rule_index[rule_id] = len(sarif_rules)
+            sarif_rules.append({
+                "id": rule_id,
+                "name": rule_id.replace("-", " ").replace("_", " ").title(),
+                "shortDescription": {"text": finding.get("title", rule_id)},
                 "defaultConfiguration": {
                     "level": _sarif_level(finding.get("severity", "MEDIUM")),
                 },
             })
 
         sarif_results.append({
-            "ruleId": category,
-            "ruleIndex": rules_seen[category],
+            "ruleId": rule_id,
+            "ruleIndex": rule_index[rule_id],
             "level": _sarif_level(finding.get("severity", "MEDIUM")),
             "message": {
                 "text": f"{finding.get('title', '')}. Evidence: {finding.get('evidence', 'N/A')}",

--- a/warden/default_policy.yaml
+++ b/warden/default_policy.yaml
@@ -50,6 +50,8 @@ settings:
 
 rules:
   # ── CRITICAL: Destructive commands ────────────────────────────────────
+  # Patterns target genuinely destructive rm invocations while allowing
+  # routine cleanup (rm -rf ./node_modules, rm -rf /tmp/my-cache, etc).
   - id: destructive-command
     severity: CRITICAL
     category: destructive_command
@@ -57,11 +59,22 @@ rules:
     event_types: [shell]
     fields: [command]
     patterns:
-      - 'rm\s+(?:-[a-zA-Z]*f[a-zA-Z]*\s+|(?:-[a-zA-Z]+\s+)*)(?:/\s*$|/\s+|/\S*\*)'
-      - 'rm\s+-[a-zA-Z]*r[a-zA-Z]*f\b|rm\s+-[a-zA-Z]*f[a-zA-Z]*r\b'
-      - 'sudo\s+rm\b'
-      - 'chmod\s+777\b'
-      - 'chown\s+-R\b'
+      # Root wipe: rm -rf /, rm -rf /*
+      - 'rm\s+(-[a-zA-Z]*[rR][a-zA-Z]*[fF][a-zA-Z]*|-[a-zA-Z]*[fF][a-zA-Z]*[rR][a-zA-Z]*)\s+/(\s|\*|$)'
+      # System-critical paths — block at any depth
+      - 'rm\s+(-[a-zA-Z]*[rR][a-zA-Z]*[fF][a-zA-Z]*|-[a-zA-Z]*[fF][a-zA-Z]*[rR][a-zA-Z]*)\s+/(etc|bin|boot|sys|proc|dev|sbin|lib(32|64)?)(/|\s|$)'
+      # Top-level user/system dirs — block only when target IS the dir (not a subpath)
+      - 'rm\s+(-[a-zA-Z]*[rR][a-zA-Z]*[fF][a-zA-Z]*|-[a-zA-Z]*[fF][a-zA-Z]*[rR][a-zA-Z]*)\s+/(home|var|usr|opt|root|System|Library|Applications)(/\*?)?(\s|$|&|;|\|)'
+      # HOME wipe
+      - 'rm\s+(-[a-zA-Z]*[rR][a-zA-Z]*[fF][a-zA-Z]*|-[a-zA-Z]*[fF][a-zA-Z]*[rR][a-zA-Z]*)\s+(\$\{?HOME\}?|~)(/\*?)?(\s|$|&|;|\|)'
+      # Cwd wildcard wipe: rm -rf *
+      - 'rm\s+(-[a-zA-Z]*[rR][a-zA-Z]*[fF][a-zA-Z]*|-[a-zA-Z]*[fF][a-zA-Z]*[rR][a-zA-Z]*)\s+\*(\s|$)'
+      # Parent-dir escape: rm -rf ../..
+      - 'rm\s+(-[a-zA-Z]*[rR][a-zA-Z]*[fF][a-zA-Z]*|-[a-zA-Z]*[fF][a-zA-Z]*[rR][a-zA-Z]*)\s+\.\.(/|\s|$)'
+      # sudo elevates blast radius — always block sudo rm -rf
+      - 'sudo\s+rm\s+(-[a-zA-Z]*[rR][a-zA-Z]*[fF][a-zA-Z]*|-[a-zA-Z]*[fF][a-zA-Z]*[rR][a-zA-Z]*)\b'
+      - 'chmod\s+777\s+(/|\$\{?HOME\}?|~|/etc|/bin|/usr|/var)'
+      - 'chown\s+-R\s+[^\n]*\s(/|\$\{?HOME\}?|~)(\s|$|/)'
       - 'mkfs\b'
       - 'dd\s+if=.*of=/dev/'
       - 'shutdown\b'
@@ -412,6 +425,40 @@ rules:
     patterns:
       - '\bsystemctl\b[^\n]*(enable|start|daemon-reload)'
       - '(^|/)\.config/systemd/user/'
+      - '(^|\n)/etc/systemd/system/'
+      - '(^|\n)/lib/systemd/system/'
+      - '(^|\n)/usr/lib/systemd/system/'
+    action: warn
+
+  # ── HIGH: Persistence — cron jobs via filesystem ──────────────────
+  # Paths anchored on `(^|\n)` because _resolve_path may prepend the
+  # original path and append the resolved one on a new line.
+  - id: persistence-cron
+    severity: HIGH
+    category: persistence
+    title: Detects writes to cron directories or /etc/crontab
+    event_types: [shell, file_write]
+    fields: [command, path]
+    patterns:
+      - '(^|\n)/etc/cron\.(d|daily|hourly|monthly|weekly)(/|\s|$)'
+      - '(^|\n)/etc/crontab(\s|$)'
+      - '(^|\n)/var/spool/cron/'
+      - '>>\s*/etc/cron'
+      - '>\s*/etc/cron'
+    action: warn
+
+  # ── HIGH: Persistence — init/rc scripts ───────────────────────────
+  - id: persistence-init
+    severity: HIGH
+    category: persistence
+    title: Detects writes to init.d, rc.local, and related boot scripts
+    event_types: [shell, file_write]
+    fields: [command, path]
+    patterns:
+      - '(^|\n)/etc/init\.d/'
+      - '(^|\n)/etc/rc\.(local|common)(\s|$)'
+      - '(^|\n)/etc/rc[0-9S]\.d/'
+      - '(^|\n)/etc/profile\.d/'
     action: warn
 
   # ── HIGH: Persistence — shell profile injection ───────────────────
@@ -463,6 +510,43 @@ rules:
       - '(^|/)\.claude/settings(\.local)?\.json$'
       - '(^|/)\.prismor-warden/policy\.yaml$'
     action: block
+
+  # ── CRITICAL: Shell obfuscation (decode-and-execute chains) ──────
+  - id: shell-obfuscation
+    severity: CRITICAL
+    category: rce_canary
+    title: Detects base64/hex/xxd decode-and-execute chains in shell
+    event_types: [shell]
+    fields: [command]
+    patterns:
+      - '\bbase64\s+(-d|--decode|-D)\b[^\n]*\|\s*(bash|sh|zsh|ksh|dash)\b'
+      - '\|\s*base64\s+(-d|--decode|-D)\b[^\n]*\|\s*(bash|sh|zsh|ksh|dash)\b'
+      - '\bprintf\s+[''"][^''"\n]*\\x[0-9a-fA-F]{2}[^''"\n]*[''"][^\n]*\|\s*(bash|sh|zsh|ksh|dash)\b'
+      - '\bxxd\s+-r\b[^\n]*\|\s*(bash|sh|zsh|ksh|dash)\b'
+      - '\becho\s+[^|\n]*\|\s*base64\s+(-d|--decode|-D)\b[^\n]*\|\s*(bash|sh|zsh)\b'
+      - '\beval\s+[\$"''][^\n]*base64\s+(-d|--decode|-D)'
+      - '\bperl\s+-e\b[^\n]*pack\s*\([''"]H\*[''"]\s*,'
+    action: block
+
+  # ── HIGH: TLS/SSL certificate verification disabled ──────────────
+  - id: tls-verification-disabled
+    severity: HIGH
+    category: security_bypass
+    title: Detects disabling of TLS/SSL certificate verification (MITM enabler)
+    event_types: [shell]
+    fields: [command]
+    patterns:
+      - '\bgit\s+config\b[^\n]*\bhttp\.sslVerify\s+false'
+      - '\bGIT_SSL_NO_VERIFY\s*=\s*(1|true|yes)'
+      - '\bStrictHostKeyChecking\s*=\s*no\b'
+      - '\bUserKnownHostsFile\s*=\s*/dev/null\b'
+      - '\bcurl\b[^\n]*\s(--insecure|-k)\b'
+      - '\bwget\b[^\n]*\s--no-check-certificate\b'
+      - '\bnpm\s+config\s+set\s+strict-ssl\s+false\b'
+      - '\bNODE_TLS_REJECT_UNAUTHORIZED\s*=\s*0\b'
+      - '\bPYTHONHTTPSVERIFY\s*=\s*0\b'
+      - '\bpip3?\s+install\b[^\n]*\s--trusted-host\b'
+    action: warn
 
   # ── CRITICAL: Claude Code credential access ───────────────────────
   - id: claude-credential-access
@@ -667,8 +751,24 @@ rules:
     fields: [command]
     patterns:
       - '\bnpm\s+publish\b[^\n]*--registry\s+https?://'
+      - '\bnpm\s+install\b[^\n]*--registry\s+https?://(?!registry\.npmjs\.org)'
+      - '\byarn\s+(add|install)\b[^\n]*--registry\s+https?://(?!registry\.npmjs\.org)'
+      - '\bpnpm\s+(add|install)\b[^\n]*--registry\s+https?://(?!registry\.npmjs\.org)'
       - '\bpip3?\s+install\b[^\n]*\s-i\s+https?://(?!pypi\.org)'
       - '\btwine\s+upload\b[^\n]*--repository-url\b'
+    action: warn
+
+  # ── HIGH: npm/yarn install from git+https (supply chain) ─────────
+  - id: npm-git-install
+    severity: HIGH
+    category: dependency_risk
+    title: npm/yarn/pnpm install from git URL bypasses registry auditing
+    event_types: [shell]
+    fields: [command]
+    patterns:
+      - '\bnpm\s+install\b[^\n]*\s(git\+https?://|git\+ssh://|git://)'
+      - '\byarn\s+add\b[^\n]*\s(git\+https?://|git\+ssh://|git://)'
+      - '\bpnpm\s+add\b[^\n]*\s(git\+https?://|git\+ssh://|git://)'
     action: warn
 
   # ── HIGH: Skill makes outbound POST/PUT requests ─────────────────

--- a/warden/default_policy.yaml
+++ b/warden/default_policy.yaml
@@ -63,7 +63,7 @@ rules:
     fields: [command]
     patterns:
       # Root wipe: rm -rf /, rm -rf /*
-      - '(?:^|\s|;|&|\|)rm\b(?=[^\n]*(?:-[a-zA-Z]*[rR][a-zA-Z]*[fF]|-[a-zA-Z]*[fF][a-zA-Z]*[rR]|\s-[rR](?=\s|$)[^\n]*\s-[fF]\b|\s-[fF](?=\s|$)[^\n]*\s-[rR]\b|--recursive\b[^\n]*--force\b|--force\b[^\n]*--recursive\b))[^\n]*\s+/(\s|\*|$)'
+      - '(?:^|\s|;|&|\|)rm\b(?=[^\n]*(?:-[a-zA-Z]*[rR][a-zA-Z]*[fF]|-[a-zA-Z]*[fF][a-zA-Z]*[rR]|\s-[rR](?=\s|$)[^\n]*\s-[fF]\b|\s-[fF](?=\s|$)[^\n]*\s-[rR]\b|--recursive\b[^\n]*--force\b|--force\b[^\n]*--recursive\b))[^\n]*\s+["'']?/["'']?(\s|\*|$)'
       # System-critical paths — block at any depth
       - '(?:^|\s|;|&|\|)rm\b(?=[^\n]*(?:-[a-zA-Z]*[rR][a-zA-Z]*[fF]|-[a-zA-Z]*[fF][a-zA-Z]*[rR]|\s-[rR](?=\s|$)[^\n]*\s-[fF]\b|\s-[fF](?=\s|$)[^\n]*\s-[rR]\b|--recursive\b[^\n]*--force\b|--force\b[^\n]*--recursive\b))[^\n]*\s+/(etc|bin|boot|sys|proc|dev|sbin|lib(32|64)?)(/|\s|$)'
       # Top-level user/system dirs — block only when target IS the dir
@@ -122,7 +122,7 @@ rules:
     fields: [command]
     patterns:
       - 'bash\s+-i\s+>&\s*/dev/tcp/'
-      - '/dev/tcp/\d'
+      - '/dev/tcp/[^\s/]+'
       # nc listener with -e/-c/--exec (explicit reverse shell)
       - '\bnc\b[^\n]*\s-[a-z]*l[a-z]*[^\n]*\s(-e|-c|--exec|--sh-exec)\b'
       # nc with combined -lvp/-lp/-pl flags (local-port + listen, typical reverse-shell setup)
@@ -545,10 +545,12 @@ rules:
     fields: [command]
     patterns:
       - '\bgit\s+config\b[^\n]*\bhttp\.sslVerify\s+false'
+      - '\bgit\b[^\n]*\s-c\s+http\.sslVerify\s*=\s*false'
       - '\bGIT_SSL_NO_VERIFY\s*=\s*(1|true|yes)'
       - '\bStrictHostKeyChecking\s*=\s*no\b'
       - '\bUserKnownHostsFile\s*=\s*/dev/null\b'
-      - '\bcurl\b[^\n]*\s(--insecure|-k)\b'
+      - '\bcurl\b[^\n]*\s--insecure\b'
+      - '\bcurl\b[^\n]*\s-[a-zA-Z]*k[a-zA-Z]*\b'
       - '\bwget\b[^\n]*\s--no-check-certificate\b'
       - '\bnpm\s+config\s+set\s+strict-ssl\s+false\b'
       - '\bNODE_TLS_REJECT_UNAUTHORIZED\s*=\s*0\b'
@@ -759,9 +761,16 @@ rules:
     fields: [command]
     patterns:
       - '\bnpm\s+publish\b[^\n]*--registry\s+https?://'
-      - '\bnpm\s+install\b[^\n]*--registry\s+https?://(?!registry\.npmjs\.org)'
-      - '\byarn\s+(add|install)\b[^\n]*--registry\s+https?://(?!registry\.npmjs\.org)'
-      - '\bpnpm\s+(add|install)\b[^\n]*--registry\s+https?://(?!registry\.npmjs\.org)'
+      # npm/yarn/pnpm with --registry anywhere in the command (flag position
+      # flexible: before or after install/i/add). Matches `npm i --registry X`,
+      # `npm --registry X install foo`, etc. Negative lookahead excludes the
+      # official registry.
+      - '\bnpm\s+(?:install|i|add)\b[^\n]*--registry\s+https?://(?!registry\.npmjs\.org)'
+      - '\bnpm\s+--registry\s+https?://(?!registry\.npmjs\.org)[^\n]*\b(install|i|add)\b'
+      - '\byarn\s+(?:add|install)\b[^\n]*--registry\s+https?://(?!registry\.npmjs\.org)'
+      - '\byarn\s+--registry\s+https?://(?!registry\.npmjs\.org)[^\n]*\b(add|install)\b'
+      - '\bpnpm\s+(?:add|install|i)\b[^\n]*--registry\s+https?://(?!registry\.npmjs\.org)'
+      - '\bpnpm\s+--registry\s+https?://(?!registry\.npmjs\.org)[^\n]*\b(add|install|i)\b'
       - '\bpip3?\s+install\b[^\n]*\s-i\s+https?://(?!pypi\.org)'
       - '\btwine\s+upload\b[^\n]*--repository-url\b'
     action: warn

--- a/warden/default_policy.yaml
+++ b/warden/default_policy.yaml
@@ -123,7 +123,12 @@ rules:
     patterns:
       - 'bash\s+-i\s+>&\s*/dev/tcp/'
       - '/dev/tcp/\d'
-      - 'nc\s+.*-[a-z]*l[a-z]*\s*.*-p'
+      # nc listener with -e/-c/--exec (explicit reverse shell)
+      - '\bnc\b[^\n]*\s-[a-z]*l[a-z]*[^\n]*\s(-e|-c|--exec|--sh-exec)\b'
+      # nc with combined -lvp/-lp/-pl flags (local-port + listen, typical reverse-shell setup)
+      - '\bnc\b[^\n]*\s-[a-z]*(?:lp|pl|lvp|pvl)[a-z]*\b'
+      # Separate nc -l and -p flags
+      - '\bnc\b[^\n]*\s-[a-z]*l[a-z]*\b[^\n]*\s-[a-z]*p[a-z]*\b'
       - 'python3?\s+-c\s+.*(?:exec|eval|import\s+os)'
       - 'perl\s+-e\s+.*(?:socket|exec)'
       - 'echo\s+.*\|\s*crontab'

--- a/warden/default_policy.yaml
+++ b/warden/default_policy.yaml
@@ -533,7 +533,7 @@ rules:
       - '\bxxd\s+-r\b[^\n]*\|\s*(bash|sh|zsh|ksh|dash)\b'
       - '\becho\s+[^|\n]*\|\s*base64\s+(-d|--decode|-D)\b[^\n]*\|\s*(bash|sh|zsh)\b'
       - '\beval\s+[\$"''][^\n]*base64\s+(-d|--decode|-D)'
-      - '\bperl\s+-e\b[^\n]*pack\s*\([''"]H\*[''"]\s*,'
+      - '\bperl\s+-e\b[^\n]*pack\s*\(\s*(?:[''"]H\*[''"]|q\{H\*\}|qq\{H\*\})\s*,'
     action: block
 
   # ── HIGH: TLS/SSL certificate verification disabled ──────────────

--- a/warden/default_policy.yaml
+++ b/warden/default_policy.yaml
@@ -51,7 +51,10 @@ settings:
 rules:
   # ── CRITICAL: Destructive commands ────────────────────────────────────
   # Patterns target genuinely destructive rm invocations while allowing
-  # routine cleanup (rm -rf ./node_modules, rm -rf /tmp/my-cache, etc).
+  # routine cleanup (rm -rf ./node_modules, rm -rf /tmp/my-cache,
+  # rm -rf ../build, etc). A lookahead verifies the command is
+  # recursive+force in any flag form (-rf, -fr, -rRf, -r -f, -f -r,
+  # --recursive, --force --recursive).
   - id: destructive-command
     severity: CRITICAL
     category: destructive_command
@@ -60,19 +63,19 @@ rules:
     fields: [command]
     patterns:
       # Root wipe: rm -rf /, rm -rf /*
-      - 'rm\s+(-[a-zA-Z]*[rR][a-zA-Z]*[fF][a-zA-Z]*|-[a-zA-Z]*[fF][a-zA-Z]*[rR][a-zA-Z]*)\s+/(\s|\*|$)'
+      - '(?:^|\s|;|&|\|)rm\b(?=[^\n]*(?:-[a-zA-Z]*[rR][a-zA-Z]*[fF]|-[a-zA-Z]*[fF][a-zA-Z]*[rR]|\s-[rR](?=\s|$)[^\n]*\s-[fF]\b|\s-[fF](?=\s|$)[^\n]*\s-[rR]\b|--recursive\b[^\n]*--force\b|--force\b[^\n]*--recursive\b))[^\n]*\s+/(\s|\*|$)'
       # System-critical paths — block at any depth
-      - 'rm\s+(-[a-zA-Z]*[rR][a-zA-Z]*[fF][a-zA-Z]*|-[a-zA-Z]*[fF][a-zA-Z]*[rR][a-zA-Z]*)\s+/(etc|bin|boot|sys|proc|dev|sbin|lib(32|64)?)(/|\s|$)'
-      # Top-level user/system dirs — block only when target IS the dir (not a subpath)
-      - 'rm\s+(-[a-zA-Z]*[rR][a-zA-Z]*[fF][a-zA-Z]*|-[a-zA-Z]*[fF][a-zA-Z]*[rR][a-zA-Z]*)\s+/(home|var|usr|opt|root|System|Library|Applications)(/\*?)?(\s|$|&|;|\|)'
+      - '(?:^|\s|;|&|\|)rm\b(?=[^\n]*(?:-[a-zA-Z]*[rR][a-zA-Z]*[fF]|-[a-zA-Z]*[fF][a-zA-Z]*[rR]|\s-[rR](?=\s|$)[^\n]*\s-[fF]\b|\s-[fF](?=\s|$)[^\n]*\s-[rR]\b|--recursive\b[^\n]*--force\b|--force\b[^\n]*--recursive\b))[^\n]*\s+/(etc|bin|boot|sys|proc|dev|sbin|lib(32|64)?)(/|\s|$)'
+      # Top-level user/system dirs — block only when target IS the dir
+      - '(?:^|\s|;|&|\|)rm\b(?=[^\n]*(?:-[a-zA-Z]*[rR][a-zA-Z]*[fF]|-[a-zA-Z]*[fF][a-zA-Z]*[rR]|\s-[rR](?=\s|$)[^\n]*\s-[fF]\b|\s-[fF](?=\s|$)[^\n]*\s-[rR]\b|--recursive\b[^\n]*--force\b|--force\b[^\n]*--recursive\b))[^\n]*\s+/(home|var|usr|opt|root|System|Library|Applications)(/\*?)?(\s|$|&|;|\|)'
       # HOME wipe
-      - 'rm\s+(-[a-zA-Z]*[rR][a-zA-Z]*[fF][a-zA-Z]*|-[a-zA-Z]*[fF][a-zA-Z]*[rR][a-zA-Z]*)\s+(\$\{?HOME\}?|~)(/\*?)?(\s|$|&|;|\|)'
+      - '(?:^|\s|;|&|\|)rm\b(?=[^\n]*(?:-[a-zA-Z]*[rR][a-zA-Z]*[fF]|-[a-zA-Z]*[fF][a-zA-Z]*[rR]|\s-[rR](?=\s|$)[^\n]*\s-[fF]\b|\s-[fF](?=\s|$)[^\n]*\s-[rR]\b|--recursive\b[^\n]*--force\b|--force\b[^\n]*--recursive\b))[^\n]*\s+(\$\{?HOME\}?|~)(/\*?)?(\s|$|&|;|\|)'
       # Cwd wildcard wipe: rm -rf *
-      - 'rm\s+(-[a-zA-Z]*[rR][a-zA-Z]*[fF][a-zA-Z]*|-[a-zA-Z]*[fF][a-zA-Z]*[rR][a-zA-Z]*)\s+\*(\s|$)'
-      # Parent-dir escape: rm -rf ../..
-      - 'rm\s+(-[a-zA-Z]*[rR][a-zA-Z]*[fF][a-zA-Z]*|-[a-zA-Z]*[fF][a-zA-Z]*[rR][a-zA-Z]*)\s+\.\.(/|\s|$)'
-      # sudo elevates blast radius — always block sudo rm -rf
-      - 'sudo\s+rm\s+(-[a-zA-Z]*[rR][a-zA-Z]*[fF][a-zA-Z]*|-[a-zA-Z]*[fF][a-zA-Z]*[rR][a-zA-Z]*)\b'
+      - '(?:^|\s|;|&|\|)rm\b(?=[^\n]*(?:-[a-zA-Z]*[rR][a-zA-Z]*[fF]|-[a-zA-Z]*[fF][a-zA-Z]*[rR]|\s-[rR](?=\s|$)[^\n]*\s-[fF]\b|\s-[fF](?=\s|$)[^\n]*\s-[rR]\b|--recursive\b[^\n]*--force\b|--force\b[^\n]*--recursive\b))[^\n]*\s+\*(\s|$|;|&|\|)'
+      # Parent-dir escape chain: rm -rf .. or ../.. (but NOT ../build)
+      - '(?:^|\s|;|&|\|)rm\b(?=[^\n]*(?:-[a-zA-Z]*[rR][a-zA-Z]*[fF]|-[a-zA-Z]*[fF][a-zA-Z]*[rR]|\s-[rR](?=\s|$)[^\n]*\s-[fF]\b|\s-[fF](?=\s|$)[^\n]*\s-[rR]\b|--recursive\b[^\n]*--force\b|--force\b[^\n]*--recursive\b))[^\n]*\s+\.\.(?:/\.\.)*/?(\s|$|&|;|\|)'
+      # sudo elevates blast radius — always block sudo rm -rf (any flag form)
+      - '(?:^|\s|;|&|\|)sudo\s+rm\b(?=[^\n]*(?:-[a-zA-Z]*[rR][a-zA-Z]*[fF]|-[a-zA-Z]*[fF][a-zA-Z]*[rR]|\s-[rR](?=\s|$)[^\n]*\s-[fF]\b|\s-[fF](?=\s|$)[^\n]*\s-[rR]\b|--recursive\b[^\n]*--force\b|--force\b[^\n]*--recursive\b))'
       - 'chmod\s+777\s+(/|\$\{?HOME\}?|~|/etc|/bin|/usr|/var)'
       - 'chown\s+-R\s+[^\n]*\s(/|\$\{?HOME\}?|~)(\s|$|/)'
       - 'mkfs\b'

--- a/warden/default_policy.yaml
+++ b/warden/default_policy.yaml
@@ -64,12 +64,12 @@ rules:
     patterns:
       # Root wipe: rm -rf /, rm -rf /*
       - '(?:^|\s|;|&|\|)rm\b(?=[^\n]*(?:-[a-zA-Z]*[rR][a-zA-Z]*[fF]|-[a-zA-Z]*[fF][a-zA-Z]*[rR]|\s-[rR](?=\s|$)[^\n]*\s-[fF]\b|\s-[fF](?=\s|$)[^\n]*\s-[rR]\b|--recursive\b[^\n]*--force\b|--force\b[^\n]*--recursive\b))[^\n]*\s+["'']?/["'']?(\s|\*|$)'
-      # System-critical paths — block at any depth
-      - '(?:^|\s|;|&|\|)rm\b(?=[^\n]*(?:-[a-zA-Z]*[rR][a-zA-Z]*[fF]|-[a-zA-Z]*[fF][a-zA-Z]*[rR]|\s-[rR](?=\s|$)[^\n]*\s-[fF]\b|\s-[fF](?=\s|$)[^\n]*\s-[rR]\b|--recursive\b[^\n]*--force\b|--force\b[^\n]*--recursive\b))[^\n]*\s+/(etc|bin|boot|sys|proc|dev|sbin|lib(32|64)?)(/|\s|$)'
+      # System-critical paths — block at any depth (optional surrounding quotes)
+      - '(?:^|\s|;|&|\|)rm\b(?=[^\n]*(?:-[a-zA-Z]*[rR][a-zA-Z]*[fF]|-[a-zA-Z]*[fF][a-zA-Z]*[rR]|\s-[rR](?=\s|$)[^\n]*\s-[fF]\b|\s-[fF](?=\s|$)[^\n]*\s-[rR]\b|--recursive\b[^\n]*--force\b|--force\b[^\n]*--recursive\b))[^\n]*\s+["'']?/(etc|bin|boot|sys|proc|dev|sbin|lib(32|64)?)(/|["'']|\s|$)'
       # Top-level user/system dirs — block only when target IS the dir
-      - '(?:^|\s|;|&|\|)rm\b(?=[^\n]*(?:-[a-zA-Z]*[rR][a-zA-Z]*[fF]|-[a-zA-Z]*[fF][a-zA-Z]*[rR]|\s-[rR](?=\s|$)[^\n]*\s-[fF]\b|\s-[fF](?=\s|$)[^\n]*\s-[rR]\b|--recursive\b[^\n]*--force\b|--force\b[^\n]*--recursive\b))[^\n]*\s+/(home|var|usr|opt|root|System|Library|Applications)(/\*?)?(\s|$|&|;|\|)'
+      - '(?:^|\s|;|&|\|)rm\b(?=[^\n]*(?:-[a-zA-Z]*[rR][a-zA-Z]*[fF]|-[a-zA-Z]*[fF][a-zA-Z]*[rR]|\s-[rR](?=\s|$)[^\n]*\s-[fF]\b|\s-[fF](?=\s|$)[^\n]*\s-[rR]\b|--recursive\b[^\n]*--force\b|--force\b[^\n]*--recursive\b))[^\n]*\s+["'']?/(home|var|usr|opt|root|System|Library|Applications)(/\*?)?(["'']|\s|$|&|;|\|)'
       # HOME wipe
-      - '(?:^|\s|;|&|\|)rm\b(?=[^\n]*(?:-[a-zA-Z]*[rR][a-zA-Z]*[fF]|-[a-zA-Z]*[fF][a-zA-Z]*[rR]|\s-[rR](?=\s|$)[^\n]*\s-[fF]\b|\s-[fF](?=\s|$)[^\n]*\s-[rR]\b|--recursive\b[^\n]*--force\b|--force\b[^\n]*--recursive\b))[^\n]*\s+(\$\{?HOME\}?|~)(/\*?)?(\s|$|&|;|\|)'
+      - '(?:^|\s|;|&|\|)rm\b(?=[^\n]*(?:-[a-zA-Z]*[rR][a-zA-Z]*[fF]|-[a-zA-Z]*[fF][a-zA-Z]*[rR]|\s-[rR](?=\s|$)[^\n]*\s-[fF]\b|\s-[fF](?=\s|$)[^\n]*\s-[rR]\b|--recursive\b[^\n]*--force\b|--force\b[^\n]*--recursive\b))[^\n]*\s+["'']?(\$\{?HOME\}?|~)(/\*?)?(["'']|\s|$|&|;|\|)'
       # Cwd wildcard wipe: rm -rf *
       - '(?:^|\s|;|&|\|)rm\b(?=[^\n]*(?:-[a-zA-Z]*[rR][a-zA-Z]*[fF]|-[a-zA-Z]*[fF][a-zA-Z]*[rR]|\s-[rR](?=\s|$)[^\n]*\s-[fF]\b|\s-[fF](?=\s|$)[^\n]*\s-[rR]\b|--recursive\b[^\n]*--force\b|--force\b[^\n]*--recursive\b))[^\n]*\s+\*(\s|$|;|&|\|)'
       # Parent-dir escape chain: rm -rf .. or ../.. (but NOT ../build)

--- a/warden/hooks.py
+++ b/warden/hooks.py
@@ -72,6 +72,20 @@ def uninstall_hooks(*, repo_root: Path, workspace: Path, agent: str, scope: str)
             if internal_hook.exists():
                 shutil.rmtree(internal_hook, ignore_errors=True)
                 removed = True
+        # Claude Code also installs separate cloaking hooks (decloak.sh,
+        # recloak-mcp.sh, userprompt-guard.sh). The detection-hook strip
+        # above only removes entries that reference cli.py, so cloaking
+        # stays behind unless we explicitly uninstall it too.
+        if current_agent == "claude":
+            try:
+                from warden.cloaking import uninstall as cloak_uninstall
+                cloak_result = cloak_uninstall(workspace=workspace, scope=scope)
+                if cloak_result.get("removed"):
+                    removed = True
+            except Exception:
+                # Cloaking is optional — swallow any error so detection-hook
+                # removal still reports cleanly.
+                pass
         results.append({"agent": current_agent, "configPath": str(config_path), "removed": removed})
     return results
 
@@ -102,6 +116,29 @@ def normalize_payload(*, agent: str, payload: Dict[str, Any], workspace: Path) -
     return {"sessionId": session_id, "event": event}
 
 
+def _default_block_categories() -> set:
+    """Return block categories from the bundled default_policy.yaml.
+
+    Cached on first call. Falls back to a hardcoded safe default if the
+    policy cannot be loaded (e.g. PyYAML missing in a minimal environment).
+    """
+    cached = getattr(_default_block_categories, "_cache", None)
+    if cached is not None:
+        return cached
+    try:
+        from warden.policy_engine import PolicyEngine
+        cats = set(PolicyEngine().block_categories)
+    except Exception:
+        cats = {
+            "destructive_command", "secret_exfiltration", "secret_access",
+            "remote_execution", "prompt_injection", "dos_resource_exhaustion",
+            "rce_canary", "db_modification", "privilege_escalation",
+            "skill_risk", "persistence", "security_bypass", "dependency_risk",
+        }
+    _default_block_categories._cache = cats  # type: ignore[attr-defined]
+    return cats
+
+
 def should_block(
     findings: List[Dict[str, Any]],
     event: Dict[str, Any],
@@ -110,7 +147,7 @@ def should_block(
     if not _is_pre_action(str(event.get("agent_event", ""))):
         return None
 
-    categories = block_categories if block_categories is not None else set()
+    categories = block_categories if block_categories is not None else _default_block_categories()
     for finding in findings:
         if finding.get("category") in categories:
             if event.get("type") == "file_read" and finding.get("category") != "secret_access":

--- a/warden/scanner.py
+++ b/warden/scanner.py
@@ -34,55 +34,76 @@ _SEVERITY_ORDER = {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3, "UNKNOWN": 4
 
 # ── Config discovery ────────────────────────────────────────────────────────
 
-def _claude_configs() -> List[Path]:
+def _claude_configs(workspace: Path) -> List[Path]:
     """Return Claude Code settings paths (user + project-level)."""
     home = Path.home()
     candidates = [
         home / ".claude" / "settings.json",
         home / ".claude.json",
+        workspace / ".claude" / "settings.json",
+        workspace / ".claude" / "settings.local.json",
+        # Per-project MCP config (Claude Code supports a dedicated file)
+        workspace / ".mcp.json",
     ]
-    # Also look for project-level .claude/settings.json in cwd
-    cwd_config = Path.cwd() / ".claude" / "settings.json"
-    if cwd_config.exists():
-        candidates.append(cwd_config)
-    return [p for p in candidates if p.exists()]
+    return [p for p in _dedupe(candidates) if p.exists()]
 
 
-def _cursor_configs() -> List[Path]:
+def _cursor_configs(workspace: Path) -> List[Path]:
     home = Path.home()
     candidates = [
         home / ".cursor" / "mcp.json",
-        Path.cwd() / ".cursor" / "mcp.json",
+        workspace / ".cursor" / "mcp.json",
     ]
-    return [p for p in candidates if p.exists()]
+    return [p for p in _dedupe(candidates) if p.exists()]
 
 
-def _windsurf_configs() -> List[Path]:
+def _windsurf_configs(workspace: Path) -> List[Path]:
     home = Path.home()
     candidates = [
         home / ".codeium" / "windsurf" / "mcp_config.json",
-        Path.cwd() / ".windsurf" / "mcp.json",
+        workspace / ".windsurf" / "mcp.json",
     ]
-    return [p for p in candidates if p.exists()]
+    return [p for p in _dedupe(candidates) if p.exists()]
 
 
-def _openclaw_configs() -> List[Path]:
+def _openclaw_configs(workspace: Path) -> List[Path]:
     home = Path.home()
     candidates = [
         home / ".openclaw" / "config.json",
         home / ".openclaw" / "skills.json",
+        workspace / ".openclaw" / "config.json",
+        workspace / ".openclaw" / "skills.json",
+        workspace / ".openclaw" / "plugins.json",
     ]
-    return [p for p in candidates if p.exists()]
+    return [p for p in _dedupe(candidates) if p.exists()]
 
 
-def _hermes_configs() -> List[Path]:
+def _hermes_configs(workspace: Path) -> List[Path]:
     home = Path.home()
     candidates = [
         home / ".hermes" / "config.json",
         home / ".hermes" / "skills.json",
         home / ".hermes" / "plugins.json",
+        workspace / ".hermes" / "config.json",
+        workspace / ".hermes" / "plugins.json",
     ]
-    return [p for p in candidates if p.exists()]
+    return [p for p in _dedupe(candidates) if p.exists()]
+
+
+def _dedupe(paths: List[Path]) -> List[Path]:
+    """De-duplicate paths (preserves order). Resolves each path first so
+    symlinks and workspace-that-equals-HOME don't produce duplicates."""
+    seen: set[str] = set()
+    out: List[Path] = []
+    for p in paths:
+        try:
+            key = str(p.resolve())
+        except (OSError, ValueError):
+            key = str(p)
+        if key not in seen:
+            seen.add(key)
+            out.append(p)
+    return out
 
 
 _AGENT_DISCOVERERS = {
@@ -94,15 +115,22 @@ _AGENT_DISCOVERERS = {
 }
 
 
-def discover_configs(agent: Optional[str] = None) -> List[Dict[str, Any]]:
-    """Find all agent config files. Returns list of {agent, path}."""
+def discover_configs(
+    agent: Optional[str] = None,
+    workspace: Optional[Path] = None,
+) -> List[Dict[str, Any]]:
+    """Find all agent config files. Returns list of {agent, path}.
+
+    Project-level configs are sourced from ``workspace`` (or CWD if omitted).
+    """
+    ws = workspace if workspace is not None else Path.cwd()
     agents = [agent] if agent else list(_AGENT_DISCOVERERS.keys())
     results: List[Dict[str, Any]] = []
     for a in agents:
         discoverer = _AGENT_DISCOVERERS.get(a)
         if not discoverer:
             continue
-        for p in discoverer():
+        for p in discoverer(ws):
             results.append({"agent": a, "path": p})
     return results
 
@@ -288,7 +316,7 @@ def scan_skills(
         }
     """
     engine = PolicyEngine(workspace=workspace)
-    configs = discover_configs(agent=agent)
+    configs = discover_configs(agent=agent, workspace=workspace)
 
     all_entries: List[Dict[str, Any]] = []
     for cfg in configs:


### PR DESCRIPTION
## Summary

Closes gaps surfaced by a full-feature audit of Immunity Agent on a fresh Ubuntu install. Groups into detection coverage, CLI correctness, and lifecycle/UX polish.

### Detection (YAML policy)
- **Tightened `destructive-command` regex.** Previously any `rm -rf` on an absolute path was blocked, so `rm -rf /tmp/build` and `rm -rf ./node_modules` triggered false positives. New patterns target root wipes, system dirs, `$HOME`/`~`, `*`, `..`, and `sudo rm -rf` — but allow routine cleanup.
- **New persistence rules** for `/etc/cron.d/`, `/etc/crontab`, `/etc/systemd/system/`, `/etc/init.d/`, `/etc/rc.local`, `/etc/profile.d/`.
- **New `tls-verification-disabled` rule** (`git config http.sslVerify false`, `GIT_SSL_NO_VERIFY`, `StrictHostKeyChecking=no`, `curl -k`, `NODE_TLS_REJECT_UNAUTHORIZED=0`, `pip --trusted-host`, etc.).
- **npm / yarn / pnpm supply-chain patterns** for `--registry` overrides and `git+https://` installs.
- **New `shell-obfuscation` rule** catches `base64 -d | bash`, `xxd -r | bash`, `printf '\xNN' | bash`, and `perl pack("H*"...)` decode-and-execute chains.

### CLI correctness
- **Workspace resolution.** argparse subparsers declaring `--workspace` were clobbering the top-level value with `None`, so `warden --workspace X scan` silently fell back to CWD. CLI now scans `argv` directly and honors `PRISMOR_WARDEN_WORKSPACE`. This single fix also restores egress allowlist enforcement in `warden check` and makes `policy init --workspace` write to the right directory.
- **Scanner** now reads `.claude/settings.json`, `.claude/settings.local.json`, and `.mcp.json` from the workspace. Previously project-level MCP configs were ignored entirely.
- **`should_block()`** loads default categories from the policy when `block_categories` is `None`, so the public API works for direct callers. Fixes three previously-failing unit tests.

### Lifecycle / UX
- **`uninstall-hooks`** now removes cloaking hooks (`userprompt-guard.sh`, `decloak.sh`, `recloak-mcp.sh`) in addition to detection hooks, leaving `settings.json` clean.
- **`sweep --clean / --restore`** catch `RuntimeError` in non-TTY contexts and exit 1 with a clean message pointing at `PRISMOR_SWEEP_PASS`, instead of printing an unhandled Python traceback.
- **`upgrade_feed.py`** is now idempotent (no-op when nothing changes), so the Ed25519 signature isn't invalidated on every run. When changes are written, it auto-re-signs via `pipeline/sign_feed.sh` if `PRISMOR_SIGNING_PRIVATE_KEY` is set; otherwise it prints a loud warning. Docstring marks it as a maintainer-only tool.
- **SARIF** now populates `rules[]` with all 53 policy rules including titles, severities, categories, and `helpUri` — previously empty even when findings existed.
- **`analyze`** and **`session`** accept positional args in addition to `--input` / `--session-id`.
- **`check`** no longer prints the resolved symlink path as a trailing line (was breaking downstream parsers).

## Test plan

- [x] `pytest` — 227/227 pass (was 223/227 on main)
- [x] Manual: `rm -rf ./node_modules`, `rm -rf /tmp/build` → PASS; `rm -rf /`, `rm -rf /etc`, `rm -rf /home/*` → BLOCK
- [x] Manual: `git config http.sslVerify false`, `curl -k`, `npm install --registry https://evil.com foo` → flagged
- [x] Manual: `/etc/cron.d/backdoor` (`--type write`), `/etc/crontab`, `/etc/systemd/system/evil.service` → persistence finding
- [x] Manual: `echo ... | base64 -d | bash` → CRITICAL rce_canary
- [x] Manual: `warden --workspace /tmp/X scan` reads `/tmp/X/.claude/settings.json` and finds the `suspicious` MCP entry
- [x] Manual: Egress allowlist in `.prismor-warden/policy.yaml` correctly warns for `curl https://malware.example.com` and passes `curl https://api.github.com`
- [x] Manual: `install-hooks --agent claude` + `cloak install` → `uninstall-hooks --agent claude` leaves `hooks: {}`
- [x] Manual: `sweep --restore </dev/null` exits 1 cleanly instead of tracebacking
- [x] Manual: `scripts/upgrade_feed.py` is no-op on a signed-and-current feed; signature still verifies
- [x] Manual: SARIF output contains 53 rule entries with `helpUri` populated