### PR TITLE
Add scoped agent and session-based learning (Tier 3)

### DIFF
--- a/warden/cli.py
+++ b/warden/cli.py
@@ -589,6 +589,30 @@ def main() -> None:
         normalized = normalize_payload(agent=args.agent, payload=payload, workspace=workspace)
         event = normalized["event"]
         append_session_event(workspace, normalized["sessionId"], event)
+
+        # ── Scoped agent: synthesize rules on first prompt ────────────
+        if event.get("agent_event") == "UserPromptSubmit":
+            try:
+                from warden.scoped_agent import (
+                    load_scoped_rules as _load_scoped,
+                    synthesize_scoped_rules as _synthesize_scoped,
+                    save_scoped_rules as _save_scoped,
+                    format_scoped_rules_box as _format_scoped_box,
+                )
+                _existing_scoped = _load_scoped(workspace, normalized["sessionId"])
+                if _existing_scoped is None and event.get("prompt"):
+                    _available_tools = ["Bash", "Read", "Edit", "MultiEdit", "Write", "WebFetch", "WebSearch"]
+                    _scoped_rules = _synthesize_scoped(
+                        goal=event["prompt"],
+                        available_tools=_available_tools,
+                        workspace=workspace,
+                    )
+                    if _scoped_rules:
+                        _save_scoped(workspace, normalized["sessionId"], _scoped_rules)
+                        sys.stderr.write(_format_scoped_box(_scoped_rules) + "\n")
+            except Exception as _scoped_exc:
+                sys.stderr.write(f"[warden] scoped agent error: {_scoped_exc}\n")
+
         events = read_session_events(workspace, normalized["sessionId"])
         result = analyze_events(events, repo_root=repo_root, workspace=workspace, session_id=normalized["sessionId"])
         save_session_snapshot(
@@ -607,6 +631,27 @@ def main() -> None:
         from warden.policy_engine import PolicyEngine as _PolicyEngine
         _current_engine = _PolicyEngine(workspace=workspace)
         current_findings = _current_engine.evaluate(event, len(events) - 1, session_id=normalized["sessionId"])
+
+        # ── Scoped agent: enforce session-scoped rules ────────────────
+        try:
+            from warden.scoped_agent import load_scoped_rules as _load_sr, check_scoped_rules as _check_sr
+            _sr = _load_sr(workspace, normalized["sessionId"])
+            if _sr is not None:
+                _sr_finding = _check_sr(_sr, event, session_id=normalized["sessionId"])
+                if _sr_finding:
+                    current_findings.append(_sr_finding)
+        except Exception as _sr_exc:
+            sys.stderr.write(f"[warden] scoped enforcement error: {_sr_exc}\n")
+
+        # ── Learning: evasion detection on passing shell events ───────
+        if not current_findings and event.get("type") == "shell":
+            try:
+                from warden.learning import detect_evasion as _detect_evasion
+                _evasion_findings = _detect_evasion(workspace, normalized["sessionId"], event, current_findings)
+                if _evasion_findings:
+                    current_findings.extend(_evasion_findings)
+            except Exception as _ev_exc:
+                sys.stderr.write(f"[warden] evasion detection error: {_ev_exc}\n")
 
         # Forward findings to configured telemetry sinks (webhook/syslog/file)
         # BEFORE the blocking decision — so a SIEM sees every event, even
@@ -643,6 +688,17 @@ def main() -> None:
         elif args.mode == "observe" and blocking is not None:
             # Show warnings in observe mode so humans/agents see feedback.
             sys.stderr.write(_color(f"[warden] ", _YELLOW) + f"[{blocking['severity']}] {blocking['title']}\n")
+            # Record as dismissal for learning (observe mode = user saw but continued)
+            try:
+                from warden.learning import record_dismissal as _record_dismissal
+                _record_dismissal(
+                    workspace, normalized["sessionId"],
+                    blocking.get("ruleId", "unknown"),
+                    blocking.get("evidence", ""),
+                    "user_skip",
+                )
+            except Exception:
+                pass  # best-effort, don't break the hook
         return
 
     # ── sweep ──────────────────────────────────────────────────────────
@@ -911,6 +967,146 @@ def main() -> None:
             _policy_test(workspace, test_file=getattr(args, "file", None))
             return
 
+    # ── scope subcommands ───────────────────────────────────────────────
+    if args.command == "scope":
+        from warden.scoped_agent import (
+            load_scoped_rules, clear_scoped_rules,
+            list_scoped_sessions, format_scoped_rules_box,
+        )
+        sub = getattr(args, "scope_command", None)
+        if sub == "show":
+            sid = getattr(args, "session_id", None)
+            if sid:
+                rules = load_scoped_rules(workspace, sid)
+                if rules is None:
+                    print(f"No scoped rules for session '{sid}'")
+                    return
+                print(format_scoped_rules_box(rules))
+            else:
+                sessions = list_scoped_sessions(workspace)
+                if not sessions:
+                    print("No active scoped sessions.")
+                    return
+                for s in sessions:
+                    print(f"\n  Session: {s['session_id']}")
+                    print(format_scoped_rules_box(s["rules"]))
+            return
+        if sub == "list":
+            sessions = list_scoped_sessions(workspace)
+            if not sessions:
+                print("No active scoped sessions.")
+                return
+            print(f"  {_color('PRISMOR WARDEN', _BOLD)}  scoped sessions")
+            print(f"  {_color('─' * 50, _DIM)}")
+            for s in sessions:
+                tools = ", ".join(s["rules"].get("allowed_tools", []))
+                print(f"  {s['session_id']}  tools: [{tools}]")
+            return
+        if sub == "edit":
+            sid = args.session_id
+            from warden.scoped_agent import _scoped_path
+            path = _scoped_path(workspace, sid)
+            if not path.exists():
+                sys.stderr.write(f"No scoped rules for session '{sid}'\n")
+                raise SystemExit(1)
+            editor = os.environ.get("EDITOR", "vi")
+            os.system(f'{editor} "{path}"')
+            return
+        if sub == "clear":
+            sid = args.session_id
+            if clear_scoped_rules(workspace, sid):
+                print(_color("Cleared", _GREEN) + f" scoped rules for session '{sid}'")
+            else:
+                print(f"No scoped rules for session '{sid}'")
+            return
+        # Default: show all
+        sessions = list_scoped_sessions(workspace)
+        if not sessions:
+            print("No active scoped sessions. Scoped rules are created automatically on session start.")
+            return
+        for s in sessions:
+            print(f"\n  Session: {s['session_id']}")
+            print(format_scoped_rules_box(s["rules"]))
+        return
+
+    # ── learn subcommand ──────────────────────────────────────────────
+    if args.command == "learn":
+        from warden.learning import (
+            mine_patterns, track_false_positives, propose_rule_refinements,
+            save_candidate_rules, list_candidate_rules,
+            accept_candidate_rule, reject_candidate_rule,
+            format_learning_report,
+        )
+
+        # Accept a candidate
+        if getattr(args, "apply", None) is not None:
+            rule = accept_candidate_rule(workspace, args.apply)
+            if rule is None:
+                sys.stderr.write(f"No pending candidate with id {args.apply}\n")
+                raise SystemExit(1)
+            # Append to project policy
+            import yaml
+            policy_path = workspace / ".prismor-warden" / "policy.yaml"
+            policy: Dict[str, Any] = {}
+            if policy_path.exists():
+                policy = yaml.safe_load(policy_path.read_text()) or {}
+            rules_list = policy.setdefault("rules", [])
+            rules_list.append(rule)
+            policy_path.parent.mkdir(parents=True, exist_ok=True)
+            policy_path.write_text(yaml.dump(policy, default_flow_style=False, sort_keys=False))
+            print(_color("Accepted", _GREEN) + f" candidate rule '{rule['id']}' → .prismor-warden/policy.yaml")
+            return
+
+        # Reject a candidate
+        if getattr(args, "reject", None) is not None:
+            if reject_candidate_rule(workspace, args.reject):
+                print(_color("Rejected", _YELLOW) + f" candidate #{args.reject}")
+            else:
+                sys.stderr.write(f"No pending candidate with id {args.reject}\n")
+                raise SystemExit(1)
+            return
+
+        # List candidates
+        if getattr(args, "candidates", False):
+            pending = list_candidate_rules(workspace, status="pending")
+            if not pending:
+                print("No pending candidate rules.")
+                return
+            print(f"  {_color('PRISMOR WARDEN', _BOLD)}  candidate rules")
+            print(f"  {_color('─' * 50, _DIM)}")
+            for c in pending:
+                rule = c["rule"]
+                print(f"  [{c['id']}] {rule.get('title', rule.get('id', '?'))}")
+                print(f"       Confidence: {c['confidence']:.0%}  |  Support: {c['support_count']}  |  Source: {c['source']}")
+                if c.get("sample_evidence"):
+                    print(f"       Sample: {c['sample_evidence'][:100]}")
+                print()
+            print(f"Use {_color('warden learn --apply ID', _BOLD)} to accept a rule.")
+            return
+
+        # Run full learning analysis
+        candidates = mine_patterns(workspace, min_support=args.min_support)
+        false_pos = track_false_positives(workspace, threshold=args.fp_threshold)
+        refinements = propose_rule_refinements(workspace)
+
+        # Save mined candidates
+        if candidates:
+            saved = save_candidate_rules(workspace, candidates)
+            if saved:
+                sys.stderr.write(f"[warden] saved {saved} candidate rule(s) to database\n")
+
+        if getattr(args, "json_output", False):
+            print(json.dumps({
+                "candidates": [{"id": c.get("id"), "rule": c["rule"], "confidence": c["confidence"],
+                                "support_count": c["support_count"], "source": c["source"]}
+                               for c in candidates],
+                "false_positives": false_pos,
+                "refinements": refinements,
+            }, indent=2))
+        else:
+            print(format_learning_report(candidates, false_pos, refinements))
+        return
+
     raise SystemExit(f"Unsupported command: {args.command}")
 
 
@@ -1105,6 +1301,42 @@ def build_parser() -> argparse.ArgumentParser:
     c_remove.add_argument("identifier", help="Canary id or path")
 
     canary_sub.add_parser("status", help="Summary of registered canaries and recent hits")
+
+    # ── scope ─────────────────────────────────────────────────────────
+    scope_parser = subparsers.add_parser(
+        "scope",
+        help="Manage session-scoped agent rules",
+    )
+    scope_sub = scope_parser.add_subparsers(dest="scope_command")
+
+    scope_show = scope_sub.add_parser("show", help="Show active scoped rules for a session")
+    scope_show.add_argument("--session-id", help="Session ID (default: list all active)")
+
+    scope_edit = scope_sub.add_parser("edit", help="Edit scoped rules in $EDITOR")
+    scope_edit.add_argument("session_id", help="Session ID to edit")
+
+    scope_clear = scope_sub.add_parser("clear", help="Remove scoped rules for a session")
+    scope_clear.add_argument("session_id", help="Session ID to clear")
+
+    scope_sub.add_parser("list", help="List all sessions with active scoped rules")
+
+    # ── learn ─────────────────────────────────────────────────────────
+    learn_parser = subparsers.add_parser(
+        "learn",
+        help="Analyze session history and propose new rules or improvements",
+    )
+    learn_parser.add_argument("--min-support", type=int, default=3,
+                              help="Minimum occurrences for pattern mining (default: 3)")
+    learn_parser.add_argument("--fp-threshold", type=int, default=5,
+                              help="Dismissal count to flag false positives (default: 5)")
+    learn_parser.add_argument("--json", action="store_true", dest="json_output",
+                              help="Output raw JSON instead of formatted report")
+    learn_parser.add_argument("--apply", metavar="RULE_ID", type=int,
+                              help="Accept a candidate rule and append to project policy")
+    learn_parser.add_argument("--reject", metavar="RULE_ID", type=int,
+                              help="Reject a candidate rule")
+    learn_parser.add_argument("--candidates", action="store_true",
+                              help="List pending candidate rules")
 
     return parser
 

--- a/warden/cli.py
+++ b/warden/cli.py
@@ -35,6 +35,7 @@ import json
 import os
 import re
 import shutil
+import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1010,7 +1011,7 @@ def main() -> None:
                 sys.stderr.write(f"No scoped rules for session '{sid}'\n")
                 raise SystemExit(1)
             editor = os.environ.get("EDITOR", "vi")
-            os.system(f'{editor} "{path}"')
+            subprocess.run([editor, str(path)])
             return
         if sub == "clear":
             sid = args.session_id

--- a/warden/learning.py
+++ b/warden/learning.py
@@ -1,0 +1,647 @@
+"""Tier 3 — Session-Based Learning for Warden.
+
+Mines historical session data to propose new detection rules, track false
+positives, and detect evasion attempts where structurally similar commands
+bypass existing rules.
+
+Usage:
+    warden learn                 # propose new rules from session history
+    warden learn --apply ID      # accept a candidate rule into project policy
+"""
+from __future__ import annotations
+
+import json
+import re
+import shlex
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from warden.store import get_db_path, initialize_database
+
+
+# ── Schema migration ───────────────────────────────────────────────────────
+
+_LEARNING_DDL = """
+CREATE TABLE IF NOT EXISTS dismissals (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    rule_id TEXT NOT NULL,
+    evidence TEXT,
+    dismissed_at TEXT NOT NULL,
+    reason TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_dismissals_rule ON dismissals(rule_id);
+
+CREATE TABLE IF NOT EXISTS candidate_rules (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    proposed_at TEXT NOT NULL,
+    status TEXT DEFAULT 'pending',
+    rule_json TEXT NOT NULL,
+    source TEXT,
+    confidence REAL DEFAULT 0.5,
+    support_count INTEGER DEFAULT 1,
+    sample_evidence TEXT
+);
+
+CREATE TABLE IF NOT EXISTS evasion_attempts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    blocked_rule_id TEXT NOT NULL,
+    blocked_command TEXT,
+    evading_command TEXT,
+    similarity_score REAL,
+    detected_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_evasion_session ON evasion_attempts(session_id);
+"""
+
+
+def initialize_learning_tables(connection: sqlite3.Connection) -> None:
+    """Add learning tables to an existing warden.db connection."""
+    connection.executescript(_LEARNING_DDL)
+
+
+# ── Command normalization ──────────────────────────────────────────────────
+
+# Patterns for shell substitution forms
+_SUBST_BACKTICK = re.compile(r"`[^`]*`")
+_SUBST_DOLLAR = re.compile(r"\$\([^)]*\)")
+_SUBST_BRACE = re.compile(r"\$\{[^}]*\}")
+_WHITESPACE = re.compile(r"\s+")
+_SHELL_SPLIT = re.compile(r"\s*(?:;|&&|\|\||[|])\s*")
+
+
+def normalize_command_structure(command: str) -> str:
+    """Normalize a shell command for structural comparison.
+
+    Strips quoting, replaces substitutions with a placeholder, collapses
+    whitespace, and sorts arguments within each pipeline stage.
+    """
+    s = command.strip()
+
+    # Replace all substitution forms with a placeholder
+    s = _SUBST_BACKTICK.sub("__SUBST__", s)
+    s = _SUBST_DOLLAR.sub("__SUBST__", s)
+    s = _SUBST_BRACE.sub("__SUBST__", s)
+
+    # Strip quotes
+    s = s.replace('"', "").replace("'", "")
+
+    # Collapse whitespace
+    s = _WHITESPACE.sub(" ", s).strip()
+
+    # Tokenize on shell metacharacters and normalize each segment
+    segments = _SHELL_SPLIT.split(s)
+    normalized_segments = []
+    for seg in segments:
+        seg = seg.strip()
+        if not seg:
+            continue
+        parts = seg.split()
+        if not parts:
+            continue
+        # Keep the base command first, sort remaining args
+        base = parts[0]
+        args = sorted(parts[1:])
+        normalized_segments.append(" ".join([base] + args))
+
+    return " | ".join(normalized_segments)
+
+
+def _tokenize(normalized: str) -> set:
+    """Split a normalized command into a set of tokens."""
+    return set(normalized.split())
+
+
+def command_structural_similarity(cmd_a: str, cmd_b: str) -> float:
+    """Compute Jaccard similarity between two commands after normalization.
+
+    Returns a float between 0.0 (completely different) and 1.0 (identical).
+    """
+    norm_a = normalize_command_structure(cmd_a)
+    norm_b = normalize_command_structure(cmd_b)
+
+    tokens_a = _tokenize(norm_a)
+    tokens_b = _tokenize(norm_b)
+
+    if not tokens_a and not tokens_b:
+        return 1.0
+    if not tokens_a or not tokens_b:
+        return 0.0
+
+    intersection = tokens_a & tokens_b
+    union = tokens_a | tokens_b
+    return len(intersection) / len(union)
+
+
+def _base_command(command: str) -> str:
+    """Extract the first command name from a shell string."""
+    normalized = normalize_command_structure(command)
+    first_segment = normalized.split(" | ")[0] if " | " in normalized else normalized
+    parts = first_segment.split()
+    return parts[0] if parts else ""
+
+
+# ── Dismissal tracking ─────────────────────────────────────────────────────
+
+def record_dismissal(
+    workspace: Path,
+    session_id: str,
+    rule_id: str,
+    evidence: str,
+    reason: str,
+) -> None:
+    """Record that a finding was dismissed or allowlisted."""
+    db_path = initialize_database(workspace)
+    conn = sqlite3.connect(db_path)
+    try:
+        initialize_learning_tables(conn)
+        conn.execute(
+            "INSERT INTO dismissals (session_id, rule_id, evidence, dismissed_at, reason) VALUES (?, ?, ?, ?, ?)",
+            (session_id, rule_id, evidence[:4000] if evidence else "",
+             datetime.now(timezone.utc).isoformat(), reason),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ── Evasion detection ──────────────────────────────────────────────────────
+
+_EVASION_THRESHOLD = 0.6
+
+
+def detect_evasion(
+    workspace: Path,
+    session_id: str,
+    event: Dict[str, Any],
+    current_findings: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Check if a passing shell command is structurally similar to a recently blocked one.
+
+    Only runs when the event has no findings (it passed policy checks).
+    Returns a list of HIGH-severity findings if evasion is detected.
+    """
+    if current_findings:
+        return []
+
+    command = event.get("command", "")
+    if not command:
+        return []
+
+    base = _base_command(command)
+    if not base:
+        return []
+
+    db_path = get_db_path(workspace)
+    if not db_path.exists():
+        return []
+
+    conn = sqlite3.connect(db_path)
+    try:
+        initialize_learning_tables(conn)
+
+        # Get recently blocked commands from this session
+        rows = conn.execute(
+            """
+            SELECT e.command_text, f.finding_id, f.title, f.category
+            FROM events e
+            JOIN findings f ON e.session_id = f.session_id
+            WHERE e.session_id = ?
+              AND e.type = 'shell'
+              AND e.command_text IS NOT NULL
+              AND e.command_text != ''
+            ORDER BY e.id DESC
+            LIMIT 50
+            """,
+            (session_id,),
+        ).fetchall()
+
+        evasion_findings = []
+        for blocked_cmd, finding_id, title, category in rows:
+            if not blocked_cmd:
+                continue
+
+            # Must share the same base command
+            if _base_command(blocked_cmd) != base:
+                continue
+
+            similarity = command_structural_similarity(command, blocked_cmd)
+            if similarity >= _EVASION_THRESHOLD:
+                # Record the evasion attempt
+                conn.execute(
+                    """
+                    INSERT INTO evasion_attempts
+                        (session_id, blocked_rule_id, blocked_command, evading_command, similarity_score, detected_at)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (session_id, finding_id, blocked_cmd[:4000], command[:4000],
+                     similarity, datetime.now(timezone.utc).isoformat()),
+                )
+                conn.commit()
+
+                evasion_findings.append({
+                    "id": f"{session_id}:evasion-{len(evasion_findings)}",
+                    "severity": "HIGH",
+                    "category": category or "evasion",
+                    "title": f"Possible evasion of: {title}",
+                    "evidence": f"Command '{command[:200]}' is {similarity:.0%} similar to blocked '{blocked_cmd[:200]}'",
+                    "ruleId": "evasion-detection",
+                    "action": "block",
+                })
+                break  # One match is enough
+
+        return evasion_findings
+    finally:
+        conn.close()
+
+
+# ── Pattern mining ─────────────────────────────────────────────────────────
+
+# Sensitive command prefixes that warrant attention even without a rule match
+_SENSITIVE_COMMANDS = {
+    "curl", "wget", "nc", "ncat", "socat", "ssh", "scp", "rsync",
+    "chmod", "chown", "chgrp", "sudo", "su", "doas",
+    "docker", "podman", "kubectl",
+    "pip", "pip3", "npm", "yarn", "gem", "cargo",
+    "eval", "exec", "source",
+}
+
+
+def mine_patterns(workspace: Path, min_support: int = 3) -> List[Dict[str, Any]]:
+    """Find recurring command patterns across sessions that have no rule coverage.
+
+    Returns candidate rule dicts for commands that appear >= min_support times
+    and involve sensitive operations.
+    """
+    db_path = get_db_path(workspace)
+    if not db_path.exists():
+        return []
+
+    conn = sqlite3.connect(db_path)
+    try:
+        # Get all shell events that have no associated finding.
+        # A finding's event_index corresponds to the event's position
+        # within its session (0-based row number by id order).
+        rows = conn.execute(
+            """
+            SELECT e.command_text, e.session_id
+            FROM events e
+            WHERE e.type = 'shell'
+              AND e.command_text IS NOT NULL
+              AND e.command_text != ''
+              AND NOT EXISTS (
+                  SELECT 1 FROM findings f
+                  WHERE f.session_id = e.session_id
+                    AND f.evidence LIKE '%' || SUBSTR(e.command_text, 1, 40) || '%'
+              )
+            """,
+        ).fetchall()
+    finally:
+        conn.close()
+
+    if not rows:
+        return []
+
+    # Group by normalized structure
+    structure_groups: Dict[str, List[Tuple[str, str]]] = {}
+    for cmd, sid in rows:
+        norm = normalize_command_structure(cmd)
+        structure_groups.setdefault(norm, []).append((cmd, sid))
+
+    candidates = []
+    for norm, entries in structure_groups.items():
+        if len(entries) < min_support:
+            continue
+
+        base = _base_command(entries[0][0])
+        if base not in _SENSITIVE_COMMANDS:
+            continue
+
+        # Build a candidate rule
+        sample = entries[0][0]
+        escaped = re.escape(base)
+        candidate = {
+            "id": f"learned-{base}-{len(candidates)}",
+            "severity": "MEDIUM",
+            "category": "learned_pattern",
+            "title": f"Recurring uncovered pattern: {base} (seen {len(entries)} times)",
+            "event_types": ["shell"],
+            "fields": ["command"],
+            "patterns": [f"(?:^|\\s|;|&|\\|){escaped}\\b"],
+            "action": "warn",
+            "enabled": True,
+        }
+        candidates.append({
+            "rule": candidate,
+            "source": "pattern_mining",
+            "confidence": min(0.9, 0.3 + (len(entries) * 0.1)),
+            "support_count": len(entries),
+            "sample_evidence": sample[:500],
+            "sessions": list({sid for _, sid in entries}),
+        })
+
+    return candidates
+
+
+# ── False positive tracking ────────────────────────────────────────────────
+
+def track_false_positives(workspace: Path, threshold: int = 5) -> List[Dict[str, Any]]:
+    """Find rules that have been dismissed more than threshold times.
+
+    Returns a list of dicts with rule_id, dismissal_count, and recommendation.
+    """
+    db_path = get_db_path(workspace)
+    if not db_path.exists():
+        return []
+
+    conn = sqlite3.connect(db_path)
+    try:
+        initialize_learning_tables(conn)
+        rows = conn.execute(
+            """
+            SELECT rule_id, COUNT(*) as cnt,
+                   GROUP_CONCAT(DISTINCT reason) as reasons,
+                   GROUP_CONCAT(evidence, '|||') as evidences
+            FROM dismissals
+            GROUP BY rule_id
+            HAVING cnt >= ?
+            ORDER BY cnt DESC
+            """,
+            (threshold,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    results = []
+    for rule_id, count, reasons, evidences in rows:
+        sample_evidence = (evidences or "").split("|||")[:3]
+        results.append({
+            "rule_id": rule_id,
+            "dismissal_count": count,
+            "reasons": reasons,
+            "sample_evidence": sample_evidence,
+            "recommendation": (
+                f"Rule '{rule_id}' has been dismissed {count} times. "
+                "Consider lowering severity or adding an allowlist entry."
+            ),
+        })
+
+    return results
+
+
+# ── Rule refinement proposals ──────────────────────────────────────────────
+
+def propose_rule_refinements(workspace: Path) -> List[Dict[str, Any]]:
+    """Analyze evasion attempts and propose broader regex patterns.
+
+    For each evasion where similarity > threshold, suggest a pattern that
+    catches both the original blocked command and the evading variant.
+    """
+    db_path = get_db_path(workspace)
+    if not db_path.exists():
+        return []
+
+    conn = sqlite3.connect(db_path)
+    try:
+        initialize_learning_tables(conn)
+        rows = conn.execute(
+            """
+            SELECT blocked_rule_id, blocked_command, evading_command, similarity_score
+            FROM evasion_attempts
+            WHERE similarity_score >= ?
+            ORDER BY detected_at DESC
+            LIMIT 100
+            """,
+            (_EVASION_THRESHOLD,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    if not rows:
+        return []
+
+    # Group by blocked_rule_id
+    by_rule: Dict[str, List[Tuple[str, str, float]]] = {}
+    for rule_id, blocked, evading, score in rows:
+        by_rule.setdefault(rule_id, []).append((blocked, evading, score))
+
+    refinements = []
+    for rule_id, attempts in by_rule.items():
+        # Find common structural elements between blocked and evading commands
+        blocked_norms = {normalize_command_structure(b) for b, _, _ in attempts}
+        evading_norms = {normalize_command_structure(e) for _, e, _ in attempts}
+
+        all_tokens = set()
+        for n in blocked_norms | evading_norms:
+            all_tokens.update(_tokenize(n))
+
+        # The base command is the anchor for the refined pattern
+        base = _base_command(attempts[0][0])
+        if not base:
+            continue
+
+        refinements.append({
+            "rule_id": rule_id,
+            "evasion_count": len(attempts),
+            "avg_similarity": sum(s for _, _, s in attempts) / len(attempts),
+            "suggestion": (
+                f"Broaden patterns for rule '{rule_id}' to catch shell substitution "
+                f"variants (backticks, $(), ${{}}) around '{base}'. "
+                f"Seen {len(attempts)} evasion attempt(s)."
+            ),
+            "sample_blocked": attempts[0][0][:200],
+            "sample_evading": attempts[0][1][:200],
+        })
+
+    return refinements
+
+
+# ── Candidate rule persistence ─────────────────────────────────────────────
+
+def save_candidate_rules(workspace: Path, candidates: List[Dict[str, Any]]) -> int:
+    """Persist mined candidate rules to the database. Returns count saved."""
+    if not candidates:
+        return 0
+
+    db_path = initialize_database(workspace)
+    conn = sqlite3.connect(db_path)
+    try:
+        initialize_learning_tables(conn)
+        now = datetime.now(timezone.utc).isoformat()
+        count = 0
+        for c in candidates:
+            conn.execute(
+                """
+                INSERT INTO candidate_rules
+                    (proposed_at, status, rule_json, source, confidence, support_count, sample_evidence)
+                VALUES (?, 'pending', ?, ?, ?, ?, ?)
+                """,
+                (now, json.dumps(c["rule"]), c["source"],
+                 c["confidence"], c["support_count"], c.get("sample_evidence", "")),
+            )
+            count += 1
+        conn.commit()
+        return count
+    finally:
+        conn.close()
+
+
+def list_candidate_rules(workspace: Path, status: str = "pending") -> List[Dict[str, Any]]:
+    """List candidate rules by status."""
+    db_path = get_db_path(workspace)
+    if not db_path.exists():
+        return []
+
+    conn = sqlite3.connect(db_path)
+    try:
+        initialize_learning_tables(conn)
+        rows = conn.execute(
+            """
+            SELECT id, proposed_at, status, rule_json, source, confidence, support_count, sample_evidence
+            FROM candidate_rules
+            WHERE status = ?
+            ORDER BY confidence DESC, support_count DESC
+            """,
+            (status,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    return [
+        {
+            "id": row[0],
+            "proposed_at": row[1],
+            "status": row[2],
+            "rule": json.loads(row[3]),
+            "source": row[4],
+            "confidence": row[5],
+            "support_count": row[6],
+            "sample_evidence": row[7],
+        }
+        for row in rows
+    ]
+
+
+def accept_candidate_rule(workspace: Path, candidate_id: int) -> Optional[Dict[str, Any]]:
+    """Mark a candidate rule as accepted and return it for policy insertion."""
+    db_path = get_db_path(workspace)
+    if not db_path.exists():
+        return None
+
+    conn = sqlite3.connect(db_path)
+    try:
+        initialize_learning_tables(conn)
+        row = conn.execute(
+            "SELECT rule_json FROM candidate_rules WHERE id = ? AND status = 'pending'",
+            (candidate_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        conn.execute(
+            "UPDATE candidate_rules SET status = 'accepted' WHERE id = ?",
+            (candidate_id,),
+        )
+        conn.commit()
+        return json.loads(row[0])
+    finally:
+        conn.close()
+
+
+def reject_candidate_rule(workspace: Path, candidate_id: int) -> bool:
+    """Mark a candidate rule as rejected."""
+    db_path = get_db_path(workspace)
+    if not db_path.exists():
+        return False
+
+    conn = sqlite3.connect(db_path)
+    try:
+        initialize_learning_tables(conn)
+        cursor = conn.execute(
+            "UPDATE candidate_rules SET status = 'rejected' WHERE id = ? AND status = 'pending'",
+            (candidate_id,),
+        )
+        conn.commit()
+        return cursor.rowcount > 0
+    finally:
+        conn.close()
+
+
+# ── Report formatting ──────────────────────────────────────────────────────
+
+_BOLD = "\033[1m"
+_NC = "\033[0m"
+_CYAN = "\033[0;36m"
+_YELLOW = "\033[1;33m"
+_GREEN = "\033[0;32m"
+_DIM = "\033[37m"
+
+
+def format_learning_report(
+    candidates: List[Dict[str, Any]],
+    false_positives: List[Dict[str, Any]],
+    refinements: List[Dict[str, Any]],
+) -> str:
+    """Format learning results for terminal display."""
+    lines: List[str] = []
+
+    lines.append(f"\n{_BOLD}Warden Learning Report{_NC}")
+    lines.append("=" * 60)
+
+    # Pattern mining results
+    lines.append(f"\n{_CYAN}Pattern Mining — Candidate Rules{_NC}")
+    if candidates:
+        for c in candidates:
+            rule = c["rule"]
+            lines.append(
+                f"  [{c['id']}] {rule['title']}"
+            )
+            lines.append(
+                f"       Confidence: {c['confidence']:.0%}  |  "
+                f"Support: {c['support_count']}  |  Source: {c['source']}"
+            )
+            if c.get("sample_evidence"):
+                lines.append(f"       Sample: {c['sample_evidence'][:100]}")
+            lines.append("")
+    else:
+        lines.append(f"  {_DIM}No new patterns found.{_NC}")
+        lines.append("")
+
+    # False positive tracking
+    lines.append(f"{_YELLOW}False Positive Tracking{_NC}")
+    if false_positives:
+        for fp in false_positives:
+            lines.append(f"  Rule: {fp['rule_id']}  |  Dismissed: {fp['dismissal_count']}x")
+            lines.append(f"       {fp['recommendation']}")
+            lines.append("")
+    else:
+        lines.append(f"  {_DIM}No false positive patterns detected.{_NC}")
+        lines.append("")
+
+    # Evasion refinements
+    lines.append(f"{_CYAN}Evasion-Based Refinements{_NC}")
+    if refinements:
+        for r in refinements:
+            lines.append(
+                f"  Rule: {r['rule_id']}  |  "
+                f"Evasions: {r['evasion_count']}  |  "
+                f"Avg similarity: {r['avg_similarity']:.0%}"
+            )
+            lines.append(f"       {r['suggestion']}")
+            lines.append("")
+    else:
+        lines.append(f"  {_DIM}No evasion patterns detected.{_NC}")
+        lines.append("")
+
+    # Summary
+    total = len(candidates) + len(false_positives) + len(refinements)
+    if total > 0:
+        lines.append(f"{_GREEN}Total insights: {total}{_NC}")
+        lines.append(f"Use {_BOLD}warden learn --apply ID{_NC} to accept a candidate rule.")
+    else:
+        lines.append(f"{_DIM}No actionable insights. Collect more session data.{_NC}")
+
+    lines.append("")
+    return "\n".join(lines)

--- a/warden/learning.py
+++ b/warden/learning.py
@@ -596,7 +596,7 @@ def format_learning_report(
         for c in candidates:
             rule = c["rule"]
             lines.append(
-                f"  [{c['id']}] {rule['title']}"
+                f"  [{c.get('id', c['rule'].get('id', '?'))}] {rule['title']}"
             )
             lines.append(
                 f"       Confidence: {c['confidence']:.0%}  |  "

--- a/warden/scoped_agent.py
+++ b/warden/scoped_agent.py
@@ -106,6 +106,12 @@ def synthesize_scoped_rules(
         if "deny_network" not in rules:
             rules["deny_network"] = True
 
+        # Clamp to the known-good available_tools list to prevent prompt injection
+        # from expanding the allowed set beyond what the agent actually has.
+        available_set = set(available_tools)
+        rules["allowed_tools"] = [t for t in rules["allowed_tools"] if t in available_set]
+        rules["deny_tools"] = [t for t in rules["deny_tools"] if t in available_set]
+
         return rules
 
     except Exception as exc:
@@ -298,7 +304,7 @@ def format_scoped_rules_box(rules: Dict[str, Any]) -> str:
         f"  deny_tools:     [{denied}]",
         f"  deny_network:   {network}",
         "",
-        "  These rules apply this session only and are not saved.",
+        "  These rules apply this session only and persist in .prismor-warden/scoped/",
     ]
 
     max_width = max(len(line) for line in content_lines) + 4

--- a/warden/scoped_agent.py
+++ b/warden/scoped_agent.py
@@ -1,0 +1,316 @@
+"""Scoped Agent — task-specific rule synthesis for Warden.
+
+Generates a minimal, session-scoped rule set at the start of each session
+based on the user's task description. Rules are enforced alongside
+policy.yaml for the duration of that session only.
+
+The active rule set becomes:  policy.yaml (base) + scoped_agent (session-only)
+"""
+from __future__ import annotations
+
+import json
+import sys
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+# ── Tool name mapping ──────────────────────────────────────────────────────
+# Maps normalized event types to the tool names used in scoped rules.
+
+_EVENT_TYPE_TO_TOOL = {
+    "shell": "Bash",
+    "file_read": "Read",
+    "file_write": "Write",
+    "network": "WebFetch",
+}
+
+
+# ── Rule synthesis ─────────────────────────────────────────────────────────
+
+_SYSTEM_PROMPT = """\
+You are a security policy synthesizer for an AI coding agent.
+Given a task description and a list of available tools, output a minimal
+JSON object that scopes the agent to only what this task genuinely requires.
+Be conservative — if a tool is not clearly needed, exclude it.
+Output only valid JSON, no explanation, no markdown fences.
+Schema:
+{
+  "allowed_tools": [...],
+  "allowed_paths": [...],
+  "deny_tools": [...],
+  "deny_network": true | false
+}
+Rules:
+- allowed_tools: tool names the task needs (from the available list)
+- allowed_paths: glob patterns for file paths the task should access
+- deny_tools: tools explicitly not needed (complement of allowed)
+- deny_network: true to block all network access, false to allow
+- If the task involves reading/editing code, allow Read/Edit/Write for relevant paths
+- If the task does NOT mention network, web, fetch, install, or download, set deny_network: true
+- Always include Read in allowed_tools (agents need to read files to orient)
+"""
+
+
+def synthesize_scoped_rules(
+    goal: str,
+    available_tools: List[str],
+    workspace: Path,
+) -> Optional[Dict[str, Any]]:
+    """Call the Anthropic API to generate scoped rules for a task.
+
+    Returns a parsed dict on success, or falls back to static heuristics
+    if the SDK is unavailable or the API call fails. Returns None only if
+    the static fallback also fails (should not happen).
+    """
+    try:
+        import anthropic  # noqa: F401
+    except ImportError:
+        sys.stderr.write(
+            "[warden] anthropic SDK not installed — using static scoped rules. "
+            "Install with: pip3 install anthropic\n"
+        )
+        return _static_fallback_rules(goal, available_tools)
+
+    import os
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if not api_key:
+        sys.stderr.write(
+            "[warden] ANTHROPIC_API_KEY not set — using static scoped rules.\n"
+        )
+        return _static_fallback_rules(goal, available_tools)
+
+    try:
+        client = anthropic.Anthropic(api_key=api_key)
+        response = client.messages.create(
+            model="claude-haiku-4-5-20251001",
+            max_tokens=300,
+            temperature=0,
+            system=_SYSTEM_PROMPT,
+            messages=[{
+                "role": "user",
+                "content": f"Task: {goal}\nAvailable tools: {', '.join(available_tools)}",
+            }],
+        )
+
+        text = response.content[0].text.strip()
+        rules = json.loads(text)
+
+        # Validate shape
+        if not isinstance(rules.get("allowed_tools"), list):
+            raise ValueError("allowed_tools must be a list")
+        if not isinstance(rules.get("deny_tools"), list):
+            rules["deny_tools"] = []
+        if not isinstance(rules.get("allowed_paths"), list):
+            rules["allowed_paths"] = ["**"]
+        if "deny_network" not in rules:
+            rules["deny_network"] = True
+
+        return rules
+
+    except Exception as exc:
+        sys.stderr.write(f"[warden] scoped agent API error: {exc} — using static fallback.\n")
+        return _static_fallback_rules(goal, available_tools)
+
+
+def _static_fallback_rules(goal: str, available_tools: List[str]) -> Dict[str, Any]:
+    """Keyword-based heuristic fallback when no API is available."""
+    goal_lower = goal.lower()
+
+    # Start with Read always allowed
+    allowed = {"Read"}
+    deny_network = True
+
+    # Detect task intent from keywords
+    edit_keywords = {"edit", "fix", "refactor", "update", "change", "modify", "add", "implement", "create", "write"}
+    test_keywords = {"test", "run", "execute", "build", "compile", "lint", "check"}
+    network_keywords = {"fetch", "download", "install", "deploy", "push", "pull", "clone", "api", "http", "url"}
+    search_keywords = {"search", "find", "grep", "look"}
+
+    if any(kw in goal_lower for kw in edit_keywords):
+        allowed.update({"Edit", "MultiEdit", "Write", "Bash"})
+    if any(kw in goal_lower for kw in test_keywords):
+        allowed.update({"Bash"})
+    if any(kw in goal_lower for kw in network_keywords):
+        allowed.update({"WebFetch", "WebSearch"})
+        deny_network = False
+    if any(kw in goal_lower for kw in search_keywords):
+        allowed.update({"Bash"})  # for grep/find
+
+    deny = [t for t in available_tools if t not in allowed]
+
+    return {
+        "allowed_tools": sorted(allowed),
+        "allowed_paths": ["**"],  # broad by default in static mode
+        "deny_tools": deny,
+        "deny_network": deny_network,
+    }
+
+
+# ── Sidecar persistence ───────────────────────────────────────────────────
+
+def _scoped_dir(workspace: Path) -> Path:
+    return workspace / ".prismor-warden" / "scoped"
+
+
+def _scoped_path(workspace: Path, session_id: str) -> Path:
+    safe = "".join(c if c.isalnum() or c in "._-" else "_" for c in session_id)
+    return _scoped_dir(workspace) / f"{safe}.json"
+
+
+def save_scoped_rules(workspace: Path, session_id: str, rules: Dict[str, Any]) -> Path:
+    """Write scoped rules to a session-specific sidecar file."""
+    path = _scoped_path(workspace, session_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(rules, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def load_scoped_rules(workspace: Path, session_id: str) -> Optional[Dict[str, Any]]:
+    """Load scoped rules for a session. Returns None if no rules exist."""
+    path = _scoped_path(workspace, session_id)
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def clear_scoped_rules(workspace: Path, session_id: str) -> bool:
+    """Remove scoped rules for a session. Returns True if file was deleted."""
+    path = _scoped_path(workspace, session_id)
+    if path.exists():
+        path.unlink()
+        return True
+    return False
+
+
+def list_scoped_sessions(workspace: Path) -> List[Dict[str, Any]]:
+    """List all sessions that have active scoped rules."""
+    scoped = _scoped_dir(workspace)
+    if not scoped.exists():
+        return []
+    results = []
+    for f in sorted(scoped.glob("*.json")):
+        try:
+            rules = json.loads(f.read_text(encoding="utf-8"))
+            results.append({
+                "session_id": f.stem,
+                "path": str(f),
+                "rules": rules,
+            })
+        except (json.JSONDecodeError, OSError):
+            continue
+    return results
+
+
+# ── Enforcement ────────────────────────────────────────────────────────────
+
+def check_scoped_rules(
+    rules: Dict[str, Any],
+    event: Dict[str, Any],
+    session_id: str = "",
+) -> Optional[Dict[str, Any]]:
+    """Check an event against session-scoped rules.
+
+    Returns a finding dict if the event is blocked, None if allowed.
+    """
+    event_type = event.get("type", "")
+    tool_name = _EVENT_TYPE_TO_TOOL.get(event_type)
+
+    # Tool check
+    if tool_name:
+        allowed = rules.get("allowed_tools", [])
+        denied = rules.get("deny_tools", [])
+
+        # Handle Write/Edit distinction: if event is file_write, check both Write and Edit
+        if event_type == "file_write":
+            if "Write" not in allowed and "Edit" not in allowed and "MultiEdit" not in allowed:
+                return _scoped_finding(
+                    session_id,
+                    f"Tool '{tool_name}' is not in scope for this session",
+                    event_type,
+                )
+        elif tool_name not in allowed or tool_name in denied:
+            return _scoped_finding(
+                session_id,
+                f"Tool '{tool_name}' is not in scope for this session",
+                event_type,
+            )
+
+    # Path check for file events
+    if event_type in ("file_read", "file_write"):
+        path = event.get("path", "")
+        if path:
+            allowed_paths = rules.get("allowed_paths", ["**"])
+            if not any(fnmatch(path, pattern) for pattern in allowed_paths):
+                return _scoped_finding(
+                    session_id,
+                    f"Path '{path}' is outside the scoped paths for this session",
+                    event_type,
+                )
+
+    # Network check
+    if event_type == "network":
+        if rules.get("deny_network", False):
+            url = event.get("url", "")
+            return _scoped_finding(
+                session_id,
+                f"Network access denied by scoped rules (url: {url[:100]})",
+                event_type,
+            )
+
+    return None
+
+
+def _scoped_finding(session_id: str, reason: str, event_type: str) -> Dict[str, Any]:
+    """Build a finding dict for a scoped rule violation."""
+    return {
+        "id": f"{session_id}:scoped-agent",
+        "severity": "HIGH",
+        "category": "scoped_agent",
+        "title": f"[scoped agent] {reason}",
+        "evidence": reason,
+        "ruleId": "scoped-agent",
+        "action": "block",
+    }
+
+
+# ── Display ────────────────────────────────────────────────────────────────
+
+_BOLD = "\033[1m"
+_NC = "\033[0m"
+_CYAN = "\033[0;36m"
+_DIM = "\033[37m"
+
+
+def format_scoped_rules_box(rules: Dict[str, Any]) -> str:
+    """Format scoped rules as an ASCII box for stderr display."""
+    allowed = ", ".join(rules.get("allowed_tools", []))
+    paths = ", ".join(rules.get("allowed_paths", []))
+    denied = ", ".join(rules.get("deny_tools", []))
+    network = "denied" if rules.get("deny_network", True) else "allowed"
+
+    content_lines = [
+        f"  allowed_tools:  [{allowed}]",
+        f"  allowed_paths:  [{paths}]",
+        f"  deny_tools:     [{denied}]",
+        f"  deny_network:   {network}",
+        "",
+        "  These rules apply this session only and are not saved.",
+    ]
+
+    max_width = max(len(line) for line in content_lines) + 4
+    border = max_width + 2
+
+    lines = []
+    header = " scoped agent rules for this session "
+    pad = border - 2 - len(header)
+    lines.append(f"{_CYAN}\u250c\u2500{header}" + "\u2500" * pad + f"\u2510{_NC}")
+    for cl in content_lines:
+        padding = border - 2 - len(cl)
+        lines.append(f"{_CYAN}\u2502{_NC}{cl}" + " " * padding + f"{_CYAN}\u2502{_NC}")
+    lines.append(f"{_CYAN}\u2514" + "\u2500" * border + f"\u2518{_NC}")
+
+    return "\n".join(lines)

--- a/warden/store.py
+++ b/warden/store.py
@@ -68,6 +68,10 @@ def get_sessions_dir(workspace: Path) -> Path:
     return get_data_dir(workspace) / "sessions"
 
 
+def get_scoped_dir(workspace: Path) -> Path:
+    return get_data_dir(workspace) / "scoped"
+
+
 def ensure_data_dirs(workspace: Path) -> None:
     get_sessions_dir(workspace).mkdir(parents=True, exist_ok=True)
 
@@ -137,6 +141,10 @@ def initialize_database(workspace: Path) -> Path:
             CREATE INDEX IF NOT EXISTS idx_findings_session_id ON findings(session_id);
             """
         )
+        # Add learning tables (Tier 3: Session-Based Learning)
+        from warden.learning import initialize_learning_tables
+        initialize_learning_tables(connection)
+
         connection.commit()
     finally:
         connection.close()

--- a/warden/store.py
+++ b/warden/store.py
@@ -68,8 +68,6 @@ def get_sessions_dir(workspace: Path) -> Path:
     return get_data_dir(workspace) / "sessions"
 
 
-def get_scoped_dir(workspace: Path) -> Path:
-    return get_data_dir(workspace) / "scoped"
 
 
 def ensure_data_dirs(workspace: Path) -> None:


### PR DESCRIPTION
## Summary

- **Scoped Agent** (`warden/scoped_agent.py`): Synthesizes minimal, task-specific rules at session start via Anthropic API (with keyword-based static fallback). Rules are enforced alongside `policy.yaml` for that session only, persisted as JSON sidecar files in `.prismor-warden/scoped/`.
- **Session-Based Learning** (`warden/learning.py`): Mines historical session data for recurring uncovered command patterns, tracks false positives from dismissed findings, and detects evasion attempts where structurally similar commands (e.g. backticks vs `$()`) bypass existing rules.
- **New CLI commands**: `warden scope show|list|edit|clear` and `warden learn [--json|--apply|--reject|--candidates]`
- **Hook-dispatch integration**: Scoped rules synthesized on `UserPromptSubmit`, enforced on `PreToolUse`. Evasion detection runs on passing shell events. Dismissals recorded in observe mode.

## Test plan

- [ ] `python3 -c "from warden.learning import *"` — module imports cleanly
- [ ] `python3 -c "from warden.scoped_agent import *"` — module imports cleanly
- [ ] `warden learn` — runs without errors, shows empty report on fresh DB
- [ ] `warden learn --json` — outputs valid JSON
- [ ] `warden scope list` — runs without errors
- [ ] Verify evasion detection: backtick vs `$()` substitution scores 1.0 similarity
- [ ] Verify scoped enforcement: tools outside `allowed_tools` are blocked, paths outside `allowed_paths` are blocked, network denied when `deny_network: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)