### PR TITLE
Add Warden web dashboard and serve command

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,30 @@ flowchart TD
 
 ---
 
+## Self-Hosted Dashboard
+
+Warden includes a built-in web dashboard that visualizes session data from your local workspace DBs. No cloud, no external services — everything runs on your machine.
+
+```bash
+python3 warden/cli.py serve            # http://127.0.0.1:7070
+python3 warden/cli.py serve --port 8080   # custom port
+```
+
+Open the URL in your browser. The dashboard polls `/api/stats` every 30 seconds and displays:
+
+- **KPIs** — active sessions, tool calls inspected, dangerous commands prevented (24h)
+- **Threats by category** — donut chart across 6 threat classes
+- **Block rate** — 30-day timeseries of intercepted vs passed events
+- **Agent breakdown** — blocked commands per agent (Claude Code, Cursor, Codex, etc.)
+- **Tool call breakdown** — event counts by tool type
+- **Top MCP & Skills** — most active MCP servers and skills with block counts
+- **Threat patterns** — recurring findings ranked by frequency
+- **Live event feed** — latest events with verdict and severity
+
+The server reads from all workspaces registered via `warden install-hooks`. If no workspaces are registered yet, it starts with empty data.
+
+---
+
 ## Capabilities
 
 - 🛡️ [Warden](docs/warden.md) covers the policy engine, session logs, security audit, and CLI reference

--- a/warden/cli.py
+++ b/warden/cli.py
@@ -15,6 +15,7 @@ Commands:
   install-hooks Install IDE hooks for real-time monitoring
   uninstall-hooks Remove IDE hooks
   hook-dispatch Internal: called by IDE hooks (not for direct use)
+  serve         Start a local HTTP API server for the Prismor web dashboard
   policy init   Generate a starter policy.yaml for your project
   policy validate  Validate a policy.yaml file
   sweep         Scan AI tool configs for leaked secrets
@@ -137,6 +138,18 @@ def main() -> None:
     # ── dashboard: global overview ───────────────────────────────────────
     if args.command == "dashboard":
         _print_dashboard()
+        return
+
+    # ── serve: local HTTP API server for web dashboard ───────────────────
+    if args.command == "serve":
+        from warden.server import run_server
+        registered = list_registered_workspaces()
+        if not registered:
+            sys.stderr.write(
+                "[warden] Warning: no registered workspaces found.\n"
+                "         Run 'warden install-hooks' in a project first to collect data.\n"
+            )
+        run_server(host=args.host, port=args.port)
         return
 
     # ── info: quick workspace summary ───────────────────────────────────
@@ -1125,6 +1138,20 @@ def build_parser() -> argparse.ArgumentParser:
 
     # ── dashboard ─────────────────────────────────────────────────────
     subparsers.add_parser("dashboard", help="Global overview of all registered workspaces")
+
+    # ── serve ──────────────────────────────────────────────────────────
+    serve_parser = subparsers.add_parser(
+        "serve",
+        help="Start a local HTTP API server for the Prismor web dashboard",
+    )
+    serve_parser.add_argument(
+        "--port", type=int, default=7070,
+        help="Port to listen on (default: 7070)",
+    )
+    serve_parser.add_argument(
+        "--host", default="127.0.0.1",
+        help="Host to bind to (default: 127.0.0.1)",
+    )
 
     # ── check ──────────────────────────────────────────────────────────
     check_parser = subparsers.add_parser("check", help="Quick pre-check a command or file path")

--- a/warden/dashboard.html
+++ b/warden/dashboard.html
@@ -1,0 +1,409 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Warden Dashboard</title>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+<style>
+  :root {
+    --purple: #B4A5F6; --pink: #E8BAEE; --amber: #F9E5A6;
+    --sky: #A8D5F7; --mint: #A7F3D0; --red: #FCA5A5;
+    --slate: #CBD5E1; --gray-50: #f9fafb; --gray-100: #f3f4f6;
+    --gray-200: #e5e7eb; --gray-300: #d1d5db; --gray-400: #9ca3af;
+    --gray-500: #6b7280; --gray-700: #374151; --gray-800: #1f2937;
+    --gray-900: #111827; --pink-600: #db2777; --green-500: #22c55e;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, monospace;
+    background: var(--gray-50); color: var(--gray-800);
+    padding: 24px; max-width: 1280px; margin: 0 auto;
+  }
+  .header {
+    display: flex; align-items: center; justify-content: space-between;
+    margin-bottom: 24px;
+  }
+  .header h1 { font-size: 18px; font-weight: 600; color: var(--gray-900); }
+  .badge {
+    font-size: 10px; padding: 2px 8px; border-radius: 9999px;
+    display: inline-flex; align-items: center; gap: 4px;
+  }
+  .badge-live { background: #dcfce7; color: #15803d; }
+  .badge-demo { background: var(--gray-100); color: var(--gray-400); }
+  .badge-dot { width: 6px; height: 6px; border-radius: 50%; }
+  .badge-live .badge-dot { background: #22c55e; }
+  .badge-demo .badge-dot { background: var(--gray-300); }
+
+  .grid { display: grid; gap: 16px; margin-bottom: 16px; }
+  .grid-3 { grid-template-columns: repeat(3, 1fr); }
+  .grid-2 { grid-template-columns: repeat(2, 1fr); }
+  .grid-1-2 { grid-template-columns: 1fr 2fr; }
+
+  .card {
+    background: #fff; border: 1px solid var(--gray-200);
+    border-radius: 8px; padding: 20px;
+  }
+  .card-title {
+    font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em;
+    color: var(--gray-400); margin-bottom: 12px;
+  }
+
+  /* KPI */
+  .kpi-value { font-size: 28px; font-weight: 600; color: var(--gray-900); }
+  .kpi-value.accent { color: var(--pink-600); }
+  .kpi-delta { font-size: 11px; color: var(--gray-400); margin-top: 4px; }
+  .kpi-delta .up { color: #ef4444; }
+  .kpi-delta .down { color: var(--green-500); }
+
+  /* Tables */
+  table { width: 100%; border-collapse: collapse; }
+  th { text-align: left; font-size: 11px; color: var(--gray-400); font-weight: 400;
+       padding-bottom: 8px; border-bottom: 1px solid var(--gray-100); }
+  th.right { text-align: right; }
+  td { padding: 6px 0; font-size: 11px; color: var(--gray-700);
+       border-bottom: 1px solid var(--gray-50); }
+  td.right { text-align: right; }
+
+  .sev-badge {
+    display: inline-block; padding: 1px 6px; border-radius: 4px;
+    font-size: 10px; font-weight: 500;
+  }
+  .sev-critical { background: #ede9fe; color: #6d28d9; border: 1px solid #c4b5fd; }
+  .sev-high { background: #fce7f3; color: #be185d; border: 1px solid #f9a8d4; }
+  .sev-medium { background: #fef9c3; color: #92400e; border: 1px solid #fde68a; }
+  .sev-low { background: #e0f2fe; color: #0369a1; border: 1px solid #7dd3fc; }
+
+  /* Live events */
+  .event-row {
+    display: flex; align-items: center; gap: 8px;
+    padding: 8px 0; border-bottom: 1px solid var(--gray-50);
+  }
+  .event-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+  .event-dot.blocked { background: #ec4899; }
+  .event-dot.allowed { background: #4ade80; }
+  .event-meta { font-size: 10px; color: var(--gray-400); }
+  .event-action { font-size: 11px; color: var(--gray-700); }
+
+  /* Users list */
+  .user-row {
+    display: flex; align-items: center; gap: 8px;
+    padding: 8px 0; border-bottom: 1px solid var(--gray-50);
+  }
+  .user-rank { font-size: 10px; color: var(--gray-300); width: 16px; text-align: right; }
+  .user-info { flex: 1; min-width: 0; }
+  .user-top { display: flex; justify-content: space-between; align-items: center; }
+  .user-id { font-size: 11px; color: var(--gray-700); }
+  .user-count { font-size: 11px; font-weight: 600; color: var(--pink-600); }
+  .user-bar { height: 4px; background: var(--gray-100); border-radius: 2px; margin-top: 4px; }
+  .user-bar-fill { height: 100%; border-radius: 2px; background: var(--purple); }
+  .user-seen { font-size: 10px; color: var(--gray-300); }
+
+  /* Donut legend */
+  .legend-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 4px 12px; margin-top: 12px; }
+  .legend-item { display: flex; align-items: center; gap: 6px; font-size: 11px; color: var(--gray-500); }
+  .legend-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+
+  .chart-container { position: relative; }
+
+  @media (max-width: 768px) {
+    .grid-3, .grid-2, .grid-1-2 { grid-template-columns: 1fr; }
+    body { padding: 12px; }
+  }
+</style>
+</head>
+<body>
+
+<div class="header">
+  <h1>Warden Dashboard</h1>
+  <span id="statusBadge" class="badge badge-demo"><span class="badge-dot"></span> loading</span>
+</div>
+
+<!-- KPI Strip -->
+<div class="grid grid-3">
+  <div class="card">
+    <div class="card-title">Active Sessions</div>
+    <div id="kpiSessions" class="kpi-value">-</div>
+  </div>
+  <div class="card">
+    <div class="card-title">Tool Calls Inspected (24h)</div>
+    <div id="kpiToolCalls" class="kpi-value">-</div>
+    <div id="kpiToolsDelta" class="kpi-delta"></div>
+  </div>
+  <div class="card">
+    <div class="card-title">Dangerous Cmds Prevented</div>
+    <div id="kpiDangerous" class="kpi-value accent">-</div>
+    <div id="kpiDangerousDelta" class="kpi-delta"></div>
+  </div>
+</div>
+
+<!-- Row 1: Threats Donut + Block Rate Line -->
+<div class="grid grid-1-2">
+  <div class="card">
+    <div class="card-title">Threats by Category</div>
+    <div class="chart-container" style="height:190px">
+      <canvas id="donutChart"></canvas>
+    </div>
+    <div id="donutLegend" class="legend-grid"></div>
+  </div>
+  <div class="card">
+    <div class="card-title">Block Rate &mdash; 30 days</div>
+    <div class="chart-container" style="height:240px">
+      <canvas id="lineChart"></canvas>
+    </div>
+  </div>
+</div>
+
+<!-- Row 2: Blocked by Agent + Tool Breakdown -->
+<div class="grid grid-2">
+  <div class="card">
+    <div class="card-title">Blocked Commands by Agent</div>
+    <div class="chart-container" style="height:200px">
+      <canvas id="agentBar"></canvas>
+    </div>
+  </div>
+  <div class="card">
+    <div class="card-title">Tool Call Breakdown</div>
+    <div class="chart-container" style="height:200px">
+      <canvas id="toolBar"></canvas>
+    </div>
+  </div>
+</div>
+
+<!-- Row 3: Top MCP & Skills -->
+<div class="grid" style="grid-template-columns:1fr">
+  <div class="card">
+    <div class="card-title">Top MCP Servers &amp; Skills</div>
+    <div class="chart-container" style="height:220px">
+      <canvas id="mcpBar"></canvas>
+    </div>
+  </div>
+</div>
+
+<!-- Row 4: Top Users + Threat Patterns -->
+<div class="grid grid-1-2">
+  <div class="card">
+    <div class="card-title">Top Users by Blocks</div>
+    <div id="usersContainer"></div>
+  </div>
+  <div class="card">
+    <div class="card-title">Top Threat Patterns</div>
+    <div style="overflow-x:auto">
+      <table>
+        <thead><tr>
+          <th>Pattern</th><th>Category</th><th class="right">Count</th><th>Last Seen</th><th>Severity</th>
+        </tr></thead>
+        <tbody id="patternsBody"></tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+<!-- Live Event Feed -->
+<div class="grid" style="grid-template-columns:1fr">
+  <div class="card">
+    <div class="card-title">Live Event Feed</div>
+    <div id="eventsContainer"></div>
+  </div>
+</div>
+
+<script>
+const COLORS = ['#B4A5F6','#E8BAEE','#F9E5A6','#A8D5F7','#A7F3D0','#FCA5A5'];
+const CAT_LABELS = {
+  prompt_injection: 'Prompt Injection', jailbreak_attempt: 'Jailbreak',
+  tool_call_abuse: 'Tool Call Abuse', secret_exfil: 'Secret Exfil',
+  malicious_mcp: 'Malicious MCP', dangerous_command: 'Dangerous Cmd',
+};
+
+function fmtNum(n) {
+  if (n >= 1000) return (n/1000).toFixed(1).replace(/\.0$/,'') + 'k';
+  return n.toLocaleString();
+}
+
+function sevClass(s) { return 'sev-' + (s || 'low'); }
+
+// ── Chart instances (reused on refresh) ─────────────────────────────────────
+let donutChart, lineChart, agentBarChart, toolBarChart, mcpBarChart;
+
+function initCharts() {
+  Chart.defaults.font.family = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+  Chart.defaults.font.size = 10;
+  Chart.defaults.color = '#9ca3af';
+
+  donutChart = new Chart(document.getElementById('donutChart'), {
+    type: 'doughnut',
+    data: { labels: [], datasets: [{ data: [], backgroundColor: COLORS, borderWidth: 0 }] },
+    options: {
+      cutout: '60%', responsive: true, maintainAspectRatio: false,
+      plugins: { legend: { display: false } },
+    },
+  });
+
+  lineChart = new Chart(document.getElementById('lineChart'), {
+    type: 'line',
+    data: { labels: [], datasets: [
+      { label: 'Passed', data: [], borderColor: '#CBD5E1', borderWidth: 1.5, pointRadius: 0, tension: 0.3 },
+      { label: 'Intercepted', data: [], borderColor: '#E8BAEE', borderWidth: 2, pointRadius: 0, tension: 0.3 },
+    ]},
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      scales: { x: { grid: { display: false }, ticks: { callback: v => v.slice(5) } }, y: { grid: { color: '#f3f4f6' } } },
+      plugins: { legend: { position: 'top', align: 'end', labels: { boxWidth: 10, padding: 8 } } },
+    },
+  });
+
+  agentBarChart = new Chart(document.getElementById('agentBar'), {
+    type: 'bar',
+    data: { labels: [], datasets: [{ label: 'Blocked', data: [], backgroundColor: '#F9E5A6', borderRadius: 4, barThickness: 14 }] },
+    options: {
+      indexAxis: 'y', responsive: true, maintainAspectRatio: false,
+      scales: { x: { grid: { color: '#f3f4f6' } }, y: { grid: { display: false } } },
+      plugins: { legend: { display: false } },
+    },
+  });
+
+  toolBarChart = new Chart(document.getElementById('toolBar'), {
+    type: 'bar',
+    data: { labels: [], datasets: [{ label: 'Calls', data: [], backgroundColor: '#A8D5F7', borderRadius: 4, barThickness: 30 }] },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      scales: { x: { grid: { display: false } }, y: { grid: { color: '#f3f4f6' } } },
+      plugins: { legend: { display: false } },
+    },
+  });
+
+  mcpBarChart = new Chart(document.getElementById('mcpBar'), {
+    type: 'bar',
+    data: { labels: [], datasets: [
+      { label: 'Total Calls', data: [], backgroundColor: '#A8D5F7', borderRadius: 4, barThickness: 18 },
+      { label: 'Blocked', data: [], backgroundColor: '#E8BAEE', borderRadius: 4, barThickness: 18 },
+    ]},
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      scales: { x: { grid: { display: false } }, y: { grid: { color: '#f3f4f6' } } },
+      plugins: { legend: { position: 'top', align: 'end', labels: { boxWidth: 10, padding: 8 } } },
+    },
+  });
+}
+
+function updateDashboard(data) {
+  // Badge
+  const badge = document.getElementById('statusBadge');
+  const hasData = data.kpis && data.kpis.toolCallsInspected24h > 0;
+  badge.className = 'badge ' + (hasData ? 'badge-live' : 'badge-demo');
+  badge.innerHTML = '<span class="badge-dot"></span> ' + (hasData ? 'live' : 'no data');
+
+  // KPIs
+  const k = data.kpis || {};
+  document.getElementById('kpiSessions').textContent = fmtNum(k.activeSessions || 0);
+  document.getElementById('kpiToolCalls').textContent = fmtNum(k.toolCallsInspected24h || 0);
+  document.getElementById('kpiDangerous').textContent = fmtNum(k.dangerousCommandsPrevented24h || 0);
+
+  const d = k.deltas || {};
+  const toolsDelta = document.getElementById('kpiToolsDelta');
+  if (d.tools !== undefined) {
+    const cls = d.tools > 0 ? 'up' : 'down';
+    toolsDelta.innerHTML = '<span class="' + cls + '">' + (d.tools > 0 ? '+' : '') + d.tools + '%</span> vs yesterday';
+  }
+  const dangDelta = document.getElementById('kpiDangerousDelta');
+  if (d.dangerous !== undefined) {
+    const cls = d.dangerous > 0 ? 'up' : 'down';
+    dangDelta.innerHTML = '<span class="' + cls + '">' + (d.dangerous > 0 ? '+' : '') + d.dangerous + '%</span> vs yesterday';
+  }
+
+  // Donut
+  const threats = data.threatsByCategory || {};
+  const catKeys = Object.keys(CAT_LABELS);
+  donutChart.data.labels = catKeys.map(k => CAT_LABELS[k]);
+  donutChart.data.datasets[0].data = catKeys.map(k => threats[k] || 0);
+  donutChart.update();
+
+  const legendEl = document.getElementById('donutLegend');
+  legendEl.innerHTML = catKeys.map((k, i) =>
+    '<div class="legend-item"><span class="legend-dot" style="background:' + COLORS[i] + '"></span>' + CAT_LABELS[k] + '</div>'
+  ).join('');
+
+  // Line chart
+  const ts = data.blockRateTimeseries || [];
+  lineChart.data.labels = ts.map(t => t.date);
+  lineChart.data.datasets[0].data = ts.map(t => t.passed);
+  lineChart.data.datasets[1].data = ts.map(t => t.intercepted);
+  lineChart.update();
+
+  // Agent bar
+  const ab = data.agentBlockedCommands || [];
+  agentBarChart.data.labels = ab.map(a => a.agent);
+  agentBarChart.data.datasets[0].data = ab.map(a => a.blocked);
+  agentBarChart.update();
+
+  // Tool bar
+  const tb = data.toolCallBreakdown || [];
+  toolBarChart.data.labels = tb.map(t => t.tool);
+  toolBarChart.data.datasets[0].data = tb.map(t => t.count);
+  toolBarChart.update();
+
+  // MCP bar
+  const mcp = data.topMcpAndSkills || [];
+  mcpBarChart.data.labels = mcp.map(m => m.name);
+  mcpBarChart.data.datasets[0].data = mcp.map(m => m.calls);
+  mcpBarChart.data.datasets[1].data = mcp.map(m => m.blocked);
+  mcpBarChart.update();
+
+  // Top users
+  const users = data.topUsersByBlocks || [];
+  const maxBlocked = users.length > 0 ? users[0].blocked : 1;
+  document.getElementById('usersContainer').innerHTML = users.map((u, i) =>
+    '<div class="user-row">' +
+      '<span class="user-rank">' + (i+1) + '</span>' +
+      '<div class="user-info">' +
+        '<div class="user-top"><span class="user-id">' + u.userId + '</span>' +
+        '<span class="user-count">' + u.blocked + '</span></div>' +
+        '<div class="user-bar"><div class="user-bar-fill" style="width:' + (u.blocked/maxBlocked*100) + '%"></div></div>' +
+      '</div>' +
+      '<span class="user-seen">' + (u.lastSeen || '') + '</span>' +
+    '</div>'
+  ).join('');
+
+  // Top patterns
+  const patterns = data.topPatterns || [];
+  document.getElementById('patternsBody').innerHTML = patterns.map(p =>
+    '<tr>' +
+      '<td>' + (p.pattern || '') + '</td>' +
+      '<td style="color:#9ca3af">' + (CAT_LABELS[p.category] || p.category) + '</td>' +
+      '<td class="right" style="font-weight:500">' + (p.count || 0) + '</td>' +
+      '<td style="color:#9ca3af">' + (p.lastSeen || '') + '</td>' +
+      '<td><span class="sev-badge ' + sevClass(p.severity) + '">' + (p.severity || 'low') + '</span></td>' +
+    '</tr>'
+  ).join('');
+
+  // Live events
+  const events = data.liveEvents || [];
+  document.getElementById('eventsContainer').innerHTML = events.slice(0, 20).map(ev =>
+    '<div class="event-row">' +
+      '<span class="event-dot ' + (ev.verdict || 'allowed') + '"></span>' +
+      '<div style="flex:1;min-width:0">' +
+        '<div class="event-meta">' + (ev.ts || '') + ' &middot; ' + (ev.agent || '') + '</div>' +
+        '<div class="event-action">' + (ev.action || '') + '</div>' +
+      '</div>' +
+      '<span class="sev-badge ' + sevClass(ev.severity) + '">' + (ev.severity || 'low') + '</span>' +
+    '</div>'
+  ).join('');
+}
+
+async function fetchStats() {
+  try {
+    const res = await fetch('/api/stats');
+    if (!res.ok) return;
+    const data = await res.json();
+    updateDashboard(data);
+  } catch (e) {
+    console.error('[warden] fetch failed:', e);
+  }
+}
+
+initCharts();
+fetchStats();
+setInterval(fetchStats, 30000);
+</script>
+</body>
+</html>

--- a/warden/dashboard.html
+++ b/warden/dashboard.html
@@ -25,6 +25,8 @@
     margin-bottom: 24px;
   }
   .header h1 { font-size: 18px; font-weight: 600; color: var(--gray-900); }
+  .header-right { display: flex; align-items: center; gap: 12px; }
+  .last-updated { font-size: 10px; color: var(--gray-400); }
   .badge {
     font-size: 10px; padding: 2px 8px; border-radius: 9999px;
     display: inline-flex; align-items: center; gap: 4px;
@@ -36,6 +38,7 @@
   .badge-demo .badge-dot { background: var(--gray-300); }
 
   .grid { display: grid; gap: 16px; margin-bottom: 16px; }
+  .grid-4 { grid-template-columns: repeat(4, 1fr); }
   .grid-3 { grid-template-columns: repeat(3, 1fr); }
   .grid-2 { grid-template-columns: repeat(2, 1fr); }
   .grid-1-2 { grid-template-columns: 1fr 2fr; }
@@ -56,14 +59,29 @@
   .kpi-delta .up { color: #ef4444; }
   .kpi-delta .down { color: var(--green-500); }
 
+  /* Severity strip */
+  .sev-card { border-left: 3px solid transparent; }
+  .sev-card.critical { border-left-color: #7c3aed; }
+  .sev-card.high     { border-left-color: #db2777; }
+  .sev-card.medium   { border-left-color: #d97706; }
+  .sev-card.low      { border-left-color: #0284c7; }
+  .sev-count { font-size: 22px; font-weight: 600; }
+  .sev-card.critical .sev-count { color: #7c3aed; }
+  .sev-card.high     .sev-count { color: #db2777; }
+  .sev-card.medium   .sev-count { color: #d97706; }
+  .sev-card.low      .sev-count { color: #0284c7; }
+  .sev-label { font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--gray-400); margin-bottom: 6px; }
+
   /* Tables */
   table { width: 100%; border-collapse: collapse; }
   th { text-align: left; font-size: 11px; color: var(--gray-400); font-weight: 400;
-       padding-bottom: 8px; border-bottom: 1px solid var(--gray-100); }
+       padding-bottom: 8px; border-bottom: 1px solid var(--gray-100); cursor: pointer; user-select: none; }
+  th:hover { color: var(--gray-700); }
   th.right { text-align: right; }
   td { padding: 6px 0; font-size: 11px; color: var(--gray-700);
-       border-bottom: 1px solid var(--gray-50); }
+       border-bottom: 1px solid var(--gray-50); vertical-align: middle; }
   td.right { text-align: right; }
+  td.mono { font-family: inherit; color: var(--gray-500); }
 
   .sev-badge {
     display: inline-block; padding: 1px 6px; border-radius: 4px;
@@ -73,6 +91,47 @@
   .sev-high { background: #fce7f3; color: #be185d; border: 1px solid #f9a8d4; }
   .sev-medium { background: #fef9c3; color: #92400e; border: 1px solid #fde68a; }
   .sev-low { background: #e0f2fe; color: #0369a1; border: 1px solid #7dd3fc; }
+
+  /* Risk bar */
+  .risk-bar-wrap { display: flex; align-items: center; gap: 6px; }
+  .risk-bar { height: 4px; flex: 1; background: var(--gray-100); border-radius: 2px; min-width: 40px; }
+  .risk-bar-fill { height: 100%; border-radius: 2px; }
+  .risk-0  { background: #4ade80; }
+  .risk-30 { background: #facc15; }
+  .risk-60 { background: #f97316; }
+  .risk-80 { background: #ef4444; }
+  .risk-num { font-size: 10px; color: var(--gray-500); min-width: 22px; text-align: right; }
+
+  /* Agent pill */
+  .agent-pill {
+    display: inline-block; padding: 1px 6px; border-radius: 4px;
+    font-size: 10px; background: var(--gray-100); color: var(--gray-600);
+  }
+
+  /* Filter bar */
+  .filter-bar {
+    display: flex; align-items: center; gap: 8px; margin-bottom: 12px; flex-wrap: wrap;
+  }
+  .filter-bar label { font-size: 10px; color: var(--gray-400); }
+  .filter-select {
+    font-family: inherit; font-size: 11px; color: var(--gray-700);
+    background: var(--gray-50); border: 1px solid var(--gray-200);
+    border-radius: 4px; padding: 3px 6px; outline: none; cursor: pointer;
+  }
+  .filter-select:focus { border-color: var(--purple); }
+  .filter-input {
+    font-family: inherit; font-size: 11px; color: var(--gray-700);
+    background: var(--gray-50); border: 1px solid var(--gray-200);
+    border-radius: 4px; padding: 3px 8px; outline: none; width: 180px;
+  }
+  .filter-input:focus { border-color: var(--purple); }
+  .filter-btn {
+    font-family: inherit; font-size: 10px; padding: 3px 10px;
+    border: 1px solid var(--gray-200); border-radius: 4px;
+    background: var(--gray-50); color: var(--gray-500); cursor: pointer;
+  }
+  .filter-btn.active { background: var(--gray-800); color: #fff; border-color: var(--gray-800); }
+  .filter-count { font-size: 10px; color: var(--gray-400); margin-left: auto; }
 
   /* Live events */
   .event-row {
@@ -106,8 +165,28 @@
 
   .chart-container { position: relative; }
 
+  /* Findings drilldown */
+  .finding-row { cursor: pointer; }
+  .finding-row:hover td { background: var(--gray-50); }
+  .finding-evidence-row { display: none; }
+  .finding-evidence-row.open { display: table-row; }
+  .finding-evidence-cell {
+    padding: 8px 12px 12px; background: var(--gray-50);
+    font-size: 11px; color: var(--gray-600); line-height: 1.6;
+  }
+  .finding-command {
+    margin-top: 6px; padding: 6px 8px;
+    background: var(--gray-900); color: #e5e7eb;
+    border-radius: 4px; font-size: 10px; word-break: break-all;
+  }
+  .finding-command:empty { display: none; }
+  .sort-indicator { font-size: 9px; margin-left: 2px; opacity: 0.5; }
+
+  /* Empty state */
+  .empty-state { padding: 24px; text-align: center; font-size: 11px; color: var(--gray-400); }
+
   @media (max-width: 768px) {
-    .grid-3, .grid-2, .grid-1-2 { grid-template-columns: 1fr; }
+    .grid-4, .grid-3, .grid-2, .grid-1-2 { grid-template-columns: 1fr; }
     body { padding: 12px; }
   }
 </style>
@@ -116,13 +195,16 @@
 
 <div class="header">
   <h1>Warden Dashboard</h1>
-  <span id="statusBadge" class="badge badge-demo"><span class="badge-dot"></span> loading</span>
+  <div class="header-right">
+    <span id="lastUpdated" class="last-updated"></span>
+    <span id="statusBadge" class="badge badge-demo"><span class="badge-dot"></span> loading</span>
+  </div>
 </div>
 
 <!-- KPI Strip -->
 <div class="grid grid-3">
   <div class="card">
-    <div class="card-title">Active Sessions</div>
+    <div class="card-title">Active Sessions (24h)</div>
     <div id="kpiSessions" class="kpi-value">-</div>
   </div>
   <div class="card">
@@ -131,9 +213,29 @@
     <div id="kpiToolsDelta" class="kpi-delta"></div>
   </div>
   <div class="card">
-    <div class="card-title">Dangerous Cmds Prevented</div>
+    <div class="card-title">Dangerous Cmds Prevented (24h)</div>
     <div id="kpiDangerous" class="kpi-value accent">-</div>
     <div id="kpiDangerousDelta" class="kpi-delta"></div>
+  </div>
+</div>
+
+<!-- Severity Strip -->
+<div class="grid grid-4">
+  <div class="card sev-card critical">
+    <div class="sev-label">Critical</div>
+    <div id="sevCritical" class="sev-count">-</div>
+  </div>
+  <div class="card sev-card high">
+    <div class="sev-label">High</div>
+    <div id="sevHigh" class="sev-count">-</div>
+  </div>
+  <div class="card sev-card medium">
+    <div class="sev-label">Medium</div>
+    <div id="sevMedium" class="sev-count">-</div>
+  </div>
+  <div class="card sev-card low">
+    <div class="sev-label">Low</div>
+    <div id="sevLow" class="sev-count">-</div>
   </div>
 </div>
 
@@ -180,10 +282,30 @@
   </div>
 </div>
 
-<!-- Row 4: Top Users + Threat Patterns -->
+<!-- Row 4: Recent Sessions -->
+<div class="grid" style="grid-template-columns:1fr">
+  <div class="card">
+    <div class="card-title">Recent Sessions</div>
+    <div style="overflow-x:auto">
+      <table id="sessionsTable">
+        <thead><tr>
+          <th data-col="sessionId">Session<span class="sort-indicator">↕</span></th>
+          <th data-col="agent">Agent<span class="sort-indicator">↕</span></th>
+          <th data-col="workspace">Workspace<span class="sort-indicator">↕</span></th>
+          <th data-col="riskScore">Risk Score<span class="sort-indicator">↕</span></th>
+          <th data-col="findingsCount" class="right">Findings<span class="sort-indicator">↕</span></th>
+          <th data-col="updatedAt">Last Active<span class="sort-indicator">↕</span></th>
+        </tr></thead>
+        <tbody id="sessionsBody"></tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+<!-- Row 5: Top Users + Threat Patterns -->
 <div class="grid grid-1-2">
   <div class="card">
-    <div class="card-title">Top Users by Blocks</div>
+    <div class="card-title">Top Sessions by Blocks</div>
     <div id="usersContainer"></div>
   </div>
   <div class="card">
@@ -199,10 +321,49 @@
   </div>
 </div>
 
-<!-- Live Event Feed -->
+<!-- Row 6: Findings Drilldown -->
+<div class="grid" style="grid-template-columns:1fr">
+  <div class="card">
+    <div class="card-title">Findings Drilldown</div>
+    <div class="filter-bar">
+      <label>Agent</label>
+      <select id="fAgent" class="filter-select"><option value="">All</option></select>
+      <label>Severity</label>
+      <select id="fSeverity" class="filter-select">
+        <option value="">All</option>
+        <option value="critical">Critical</option>
+        <option value="high">High</option>
+        <option value="medium">Medium</option>
+        <option value="low">Low</option>
+      </select>
+      <label>Category</label>
+      <select id="fCategory" class="filter-select"><option value="">All</option></select>
+      <input id="fSearch" class="filter-input" type="text" placeholder="search title or command…" />
+      <span id="findingsCount" class="filter-count"></span>
+    </div>
+    <div style="overflow-x:auto">
+      <table>
+        <thead><tr>
+          <th>Finding</th><th>Agent</th><th>Category</th><th>Severity</th><th>When</th><th style="width:16px"></th>
+        </tr></thead>
+        <tbody id="findingsBody"></tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+<!-- Row 7: Live Event Feed -->
 <div class="grid" style="grid-template-columns:1fr">
   <div class="card">
     <div class="card-title">Live Event Feed</div>
+    <div class="filter-bar">
+      <button class="filter-btn active" data-verdict="">All</button>
+      <button class="filter-btn" data-verdict="blocked">Blocked</button>
+      <button class="filter-btn" data-verdict="allowed">Allowed</button>
+      <label style="margin-left:8px">Agent</label>
+      <select id="eAgent" class="filter-select"><option value="">All</option></select>
+      <span id="eventsCount" class="filter-count"></span>
+    </div>
     <div id="eventsContainer"></div>
   </div>
 </div>
@@ -215,14 +376,35 @@ const CAT_LABELS = {
   malicious_mcp: 'Malicious MCP', dangerous_command: 'Dangerous Cmd',
 };
 
+function safe(s) {
+  const d = document.createElement('span');
+  d.textContent = String(s || '');
+  return d.outerHTML;
+}
+
 function fmtNum(n) {
-  if (n >= 1000) return (n/1000).toFixed(1).replace(/\.0$/,'') + 'k';
+  if (n >= 1000) return (n / 1000).toFixed(1).replace(/\.0$/, '') + 'k';
   return n.toLocaleString();
 }
 
 function sevClass(s) { return 'sev-' + (s || 'low'); }
 
-// ── Chart instances (reused on refresh) ─────────────────────────────────────
+function riskClass(n) {
+  if (n >= 80) return 'risk-80';
+  if (n >= 60) return 'risk-60';
+  if (n >= 30) return 'risk-30';
+  return 'risk-0';
+}
+
+// ── State ────────────────────────────────────────────────────────────────────
+let _allFindings = [];
+let _allEvents = [];
+let _sessionsData = [];
+let _sessionsSort = { col: 'updatedAt', dir: -1 };
+let _evtVerdict = '';
+let _evtAgent = '';
+
+// ── Chart instances ──────────────────────────────────────────────────────────
 let donutChart, lineChart, agentBarChart, toolBarChart, mcpBarChart;
 
 function initCharts() {
@@ -247,7 +429,10 @@ function initCharts() {
     ]},
     options: {
       responsive: true, maintainAspectRatio: false,
-      scales: { x: { grid: { display: false }, ticks: { callback: v => v.slice(5) } }, y: { grid: { color: '#f3f4f6' } } },
+      scales: {
+        x: { grid: { display: false }, ticks: { callback: v => String(v).slice(5) } },
+        y: { grid: { color: '#f3f4f6' } },
+      },
       plugins: { legend: { position: 'top', align: 'end', labels: { boxWidth: 10, padding: 8 } } },
     },
   });
@@ -286,12 +471,169 @@ function initCharts() {
   });
 }
 
+// ── Sessions table ───────────────────────────────────────────────────────────
+function renderSessions() {
+  const rows = [..._sessionsData].sort((a, b) => {
+    let av = a[_sessionsSort.col], bv = b[_sessionsSort.col];
+    if (typeof av === 'number') return _sessionsSort.dir * (av - bv);
+    return _sessionsSort.dir * String(av || '').localeCompare(String(bv || ''));
+  });
+
+  const tbody = document.getElementById('sessionsBody');
+  if (!rows.length) {
+    tbody.innerHTML = '<tr><td colspan="6" class="empty-state">No sessions yet</td></tr>';
+    return;
+  }
+  tbody.innerHTML = rows.map(s => {
+    const rc = riskClass(s.riskScore);
+    const hasFi = s.findingsCount > 0;
+    return '<tr>' +
+      '<td class="mono">' + safe(s.sessionId) + '</td>' +
+      '<td><span class="agent-pill">' + safe(s.agent) + '</span></td>' +
+      '<td style="color:var(--gray-500)">' + safe(s.workspace) + '</td>' +
+      '<td><div class="risk-bar-wrap"><div class="risk-bar"><div class="risk-bar-fill ' + rc + '" style="width:' + s.riskScore + '%"></div></div><span class="risk-num">' + s.riskScore + '</span></div></td>' +
+      '<td class="right" style="' + (hasFi ? 'color:var(--pink-600);font-weight:600' : '') + '">' + s.findingsCount + '</td>' +
+      '<td style="color:var(--gray-400)">' + safe(s.updatedAt) + '</td>' +
+    '</tr>';
+  }).join('');
+}
+
+document.getElementById('sessionsTable').querySelector('thead').addEventListener('click', e => {
+  const th = e.target.closest('th[data-col]');
+  if (!th) return;
+  const col = th.dataset.col;
+  _sessionsSort.dir = (_sessionsSort.col === col) ? -_sessionsSort.dir : -1;
+  _sessionsSort.col = col;
+  renderSessions();
+});
+
+// ── Findings drilldown ───────────────────────────────────────────────────────
+function populateFindingFilters(findings) {
+  const agents = [...new Set(findings.map(f => f.agent))].sort();
+  const cats = [...new Set(findings.map(f => f.category))].sort();
+
+  const fAgent = document.getElementById('fAgent');
+  const cur = fAgent.value;
+  fAgent.innerHTML = '<option value="">All</option>' +
+    agents.map(a => '<option value="' + a + '"' + (a === cur ? ' selected' : '') + '>' + a + '</option>').join('');
+
+  const fCat = document.getElementById('fCategory');
+  const curC = fCat.value;
+  fCat.innerHTML = '<option value="">All</option>' +
+    cats.map(c => '<option value="' + c + '"' + (c === curC ? ' selected' : '') + '>' + (CAT_LABELS[c] || c) + '</option>').join('');
+}
+
+function renderFindings() {
+  const agent = document.getElementById('fAgent').value;
+  const severity = document.getElementById('fSeverity').value;
+  const category = document.getElementById('fCategory').value;
+  const search = document.getElementById('fSearch').value.toLowerCase();
+
+  const filtered = _allFindings.filter(f =>
+    (!agent || f.agent === agent) &&
+    (!severity || f.severity === severity) &&
+    (!category || f.category === category) &&
+    (!search || f.title.toLowerCase().includes(search) || (f.command || '').toLowerCase().includes(search))
+  );
+
+  document.getElementById('findingsCount').textContent = filtered.length + ' of ' + _allFindings.length;
+
+  const tbody = document.getElementById('findingsBody');
+  if (!filtered.length) {
+    tbody.innerHTML = '<tr><td colspan="6" class="empty-state">No findings match the current filters</td></tr>';
+    return;
+  }
+
+  tbody.innerHTML = filtered.map((f, i) => {
+    const eid = 'fe-' + i;
+    return '<tr class="finding-row" onclick="toggleEvidence(\'' + eid + '\')">' +
+      '<td>' + safe(f.title) + '</td>' +
+      '<td><span class="agent-pill">' + safe(f.agent) + '</span></td>' +
+      '<td style="color:var(--gray-500)">' + safe(CAT_LABELS[f.category] || f.category) + '</td>' +
+      '<td><span class="sev-badge ' + sevClass(f.severity) + '">' + safe(f.severity) + '</span></td>' +
+      '<td style="color:var(--gray-400)">' + safe(f.ts) + '</td>' +
+      '<td style="color:var(--gray-300);font-size:9px">▸</td>' +
+    '</tr>' +
+    '<tr id="' + eid + '" class="finding-evidence-row">' +
+      '<td class="finding-evidence-cell" colspan="6">' +
+        '<div>' + safe(f.evidence || 'No evidence recorded.') + '</div>' +
+        '<div class="finding-command">' + safe(f.command) + '</div>' +
+        '<div style="margin-top:6px;font-size:10px;color:var(--gray-400)">session: ' + safe(f.sessionId) + '</div>' +
+      '</td>' +
+    '</tr>';
+  }).join('');
+}
+
+function toggleEvidence(id) {
+  const row = document.getElementById(id);
+  if (!row) return;
+  row.classList.toggle('open');
+  const arrow = row.previousElementSibling.querySelector('td:last-child');
+  if (arrow) arrow.textContent = row.classList.contains('open') ? '▾' : '▸';
+}
+
+['fAgent','fSeverity','fCategory'].forEach(id =>
+  document.getElementById(id).addEventListener('change', renderFindings)
+);
+document.getElementById('fSearch').addEventListener('input', renderFindings);
+
+// ── Live event feed ──────────────────────────────────────────────────────────
+function populateEventAgents(events) {
+  const agents = [...new Set(events.map(e => e.agent))].sort();
+  const sel = document.getElementById('eAgent');
+  const cur = sel.value;
+  sel.innerHTML = '<option value="">All</option>' +
+    agents.map(a => '<option value="' + a + '"' + (a === cur ? ' selected' : '') + '>' + a + '</option>').join('');
+}
+
+function renderEvents() {
+  const filtered = _allEvents.filter(ev =>
+    (!_evtVerdict || ev.verdict === _evtVerdict) &&
+    (!_evtAgent || ev.agent === _evtAgent)
+  );
+
+  document.getElementById('eventsCount').textContent = filtered.length + ' events';
+
+  const container = document.getElementById('eventsContainer');
+  if (!filtered.length) {
+    container.innerHTML = '<div class="empty-state">No events match the current filters</div>';
+    return;
+  }
+
+  container.innerHTML = filtered.slice(0, 30).map(ev =>
+    '<div class="event-row">' +
+      '<span class="event-dot ' + (ev.verdict || 'allowed') + '"></span>' +
+      '<div style="flex:1;min-width:0">' +
+        '<div class="event-meta">' + safe(ev.ts) + ' &middot; ' + safe(ev.agent) + '</div>' +
+        '<div class="event-action">' + safe(ev.action) + '</div>' +
+      '</div>' +
+      '<span class="sev-badge ' + sevClass(ev.severity) + '">' + safe(ev.severity) + '</span>' +
+    '</div>'
+  ).join('');
+}
+
+document.querySelectorAll('.filter-btn[data-verdict]').forEach(btn => {
+  btn.addEventListener('click', () => {
+    document.querySelectorAll('.filter-btn[data-verdict]').forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+    _evtVerdict = btn.dataset.verdict;
+    renderEvents();
+  });
+});
+
+document.getElementById('eAgent').addEventListener('change', e => {
+  _evtAgent = e.target.value;
+  renderEvents();
+});
+
+// ── Main update ──────────────────────────────────────────────────────────────
 function updateDashboard(data) {
-  // Badge
+  // Badge + timestamp
   const badge = document.getElementById('statusBadge');
   const hasData = data.kpis && data.kpis.toolCallsInspected24h > 0;
   badge.className = 'badge ' + (hasData ? 'badge-live' : 'badge-demo');
   badge.innerHTML = '<span class="badge-dot"></span> ' + (hasData ? 'live' : 'no data');
+  document.getElementById('lastUpdated').textContent = 'updated ' + new Date().toLocaleTimeString();
 
   // KPIs
   const k = data.kpis || {};
@@ -310,6 +652,13 @@ function updateDashboard(data) {
     const cls = d.dangerous > 0 ? 'up' : 'down';
     dangDelta.innerHTML = '<span class="' + cls + '">' + (d.dangerous > 0 ? '+' : '') + d.dangerous + '%</span> vs yesterday';
   }
+
+  // Severity strip
+  const sv = data.severityBreakdown || {};
+  document.getElementById('sevCritical').textContent = fmtNum(sv.critical || 0);
+  document.getElementById('sevHigh').textContent = fmtNum(sv.high || 0);
+  document.getElementById('sevMedium').textContent = fmtNum(sv.medium || 0);
+  document.getElementById('sevLow').textContent = fmtNum(sv.low || 0);
 
   // Donut
   const threats = data.threatsByCategory || {};
@@ -349,45 +698,46 @@ function updateDashboard(data) {
   mcpBarChart.data.datasets[1].data = mcp.map(m => m.blocked);
   mcpBarChart.update();
 
+  // Sessions
+  _sessionsData = data.recentSessions || [];
+  renderSessions();
+
   // Top users
   const users = data.topUsersByBlocks || [];
   const maxBlocked = users.length > 0 ? users[0].blocked : 1;
   document.getElementById('usersContainer').innerHTML = users.map((u, i) =>
     '<div class="user-row">' +
-      '<span class="user-rank">' + (i+1) + '</span>' +
+      '<span class="user-rank">' + (i + 1) + '</span>' +
       '<div class="user-info">' +
-        '<div class="user-top"><span class="user-id">' + u.userId + '</span>' +
+        '<div class="user-top"><span class="user-id">' + safe(u.userId) + '</span>' +
         '<span class="user-count">' + u.blocked + '</span></div>' +
-        '<div class="user-bar"><div class="user-bar-fill" style="width:' + (u.blocked/maxBlocked*100) + '%"></div></div>' +
+        '<div class="user-bar"><div class="user-bar-fill" style="width:' + (u.blocked / maxBlocked * 100) + '%"></div></div>' +
       '</div>' +
-      '<span class="user-seen">' + (u.lastSeen || '') + '</span>' +
+      '<span class="user-seen">' + safe(u.lastSeen || '') + '</span>' +
     '</div>'
   ).join('');
 
-  // Top patterns
+  // Threat patterns
   const patterns = data.topPatterns || [];
   document.getElementById('patternsBody').innerHTML = patterns.map(p =>
     '<tr>' +
-      '<td>' + (p.pattern || '') + '</td>' +
-      '<td style="color:#9ca3af">' + (CAT_LABELS[p.category] || p.category) + '</td>' +
+      '<td>' + safe(p.pattern || '') + '</td>' +
+      '<td style="color:#9ca3af">' + safe(CAT_LABELS[p.category] || p.category) + '</td>' +
       '<td class="right" style="font-weight:500">' + (p.count || 0) + '</td>' +
-      '<td style="color:#9ca3af">' + (p.lastSeen || '') + '</td>' +
-      '<td><span class="sev-badge ' + sevClass(p.severity) + '">' + (p.severity || 'low') + '</span></td>' +
+      '<td style="color:#9ca3af">' + safe(p.lastSeen || '') + '</td>' +
+      '<td><span class="sev-badge ' + sevClass(p.severity) + '">' + safe(p.severity || 'low') + '</span></td>' +
     '</tr>'
   ).join('');
 
+  // Findings drilldown
+  _allFindings = data.recentFindings || [];
+  populateFindingFilters(_allFindings);
+  renderFindings();
+
   // Live events
-  const events = data.liveEvents || [];
-  document.getElementById('eventsContainer').innerHTML = events.slice(0, 20).map(ev =>
-    '<div class="event-row">' +
-      '<span class="event-dot ' + (ev.verdict || 'allowed') + '"></span>' +
-      '<div style="flex:1;min-width:0">' +
-        '<div class="event-meta">' + (ev.ts || '') + ' &middot; ' + (ev.agent || '') + '</div>' +
-        '<div class="event-action">' + (ev.action || '') + '</div>' +
-      '</div>' +
-      '<span class="sev-badge ' + sevClass(ev.severity) + '">' + (ev.severity || 'low') + '</span>' +
-    '</div>'
-  ).join('');
+  _allEvents = data.liveEvents || [];
+  populateEventAgents(_allEvents);
+  renderEvents();
 }
 
 async function fetchStats() {

--- a/warden/dashboard.html
+++ b/warden/dashboard.html
@@ -70,32 +70,42 @@
   .sev-card.high     .sev-count { color: #db2777; }
   .sev-card.medium   .sev-count { color: #d97706; }
   .sev-card.low      .sev-count { color: #0284c7; }
-  .sev-label { font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--gray-400); margin-bottom: 6px; }
+  .sev-label { font-size: 10px; text-transform: uppercase; letter-spacing: 0.08em;
+               color: var(--gray-400); margin-bottom: 6px; }
 
   /* Tables */
   table { width: 100%; border-collapse: collapse; }
-  th { text-align: left; font-size: 11px; color: var(--gray-400); font-weight: 400;
-       padding-bottom: 8px; border-bottom: 1px solid var(--gray-100); cursor: pointer; user-select: none; }
+  th {
+    text-align: left; font-size: 11px; color: var(--gray-400); font-weight: 400;
+    padding-bottom: 8px; border-bottom: 1px solid var(--gray-100);
+    cursor: pointer; user-select: none; white-space: nowrap;
+  }
   th:hover { color: var(--gray-700); }
   th.right { text-align: right; }
-  td { padding: 6px 0; font-size: 11px; color: var(--gray-700);
-       border-bottom: 1px solid var(--gray-50); vertical-align: middle; }
+  th .sort-ind { font-size: 9px; margin-left: 3px; opacity: 0.4; }
+  th.active-sort { color: var(--gray-700); }
+  th.active-sort .sort-ind { opacity: 1; }
+  td {
+    padding: 6px 0; font-size: 11px; color: var(--gray-700);
+    border-bottom: 1px solid var(--gray-50); vertical-align: middle;
+  }
   td.right { text-align: right; }
-  td.mono { font-family: inherit; color: var(--gray-500); }
+  td.mono { color: var(--gray-500); }
 
+  /* Severity badges */
   .sev-badge {
     display: inline-block; padding: 1px 6px; border-radius: 4px;
     font-size: 10px; font-weight: 500;
   }
   .sev-critical { background: #ede9fe; color: #6d28d9; border: 1px solid #c4b5fd; }
-  .sev-high { background: #fce7f3; color: #be185d; border: 1px solid #f9a8d4; }
-  .sev-medium { background: #fef9c3; color: #92400e; border: 1px solid #fde68a; }
-  .sev-low { background: #e0f2fe; color: #0369a1; border: 1px solid #7dd3fc; }
+  .sev-high     { background: #fce7f3; color: #be185d; border: 1px solid #f9a8d4; }
+  .sev-medium   { background: #fef9c3; color: #92400e; border: 1px solid #fde68a; }
+  .sev-low      { background: #e0f2fe; color: #0369a1; border: 1px solid #7dd3fc; }
 
   /* Risk bar */
-  .risk-bar-wrap { display: flex; align-items: center; gap: 6px; }
-  .risk-bar { height: 4px; flex: 1; background: var(--gray-100); border-radius: 2px; min-width: 40px; }
-  .risk-bar-fill { height: 100%; border-radius: 2px; }
+  .risk-wrap { display: flex; align-items: center; gap: 6px; }
+  .risk-bar  { height: 4px; flex: 1; background: var(--gray-100); border-radius: 2px; min-width: 40px; }
+  .risk-fill { height: 100%; border-radius: 2px; }
   .risk-0  { background: #4ade80; }
   .risk-30 { background: #facc15; }
   .risk-60 { background: #f97316; }
@@ -104,34 +114,63 @@
 
   /* Agent pill */
   .agent-pill {
-    display: inline-block; padding: 1px 6px; border-radius: 4px;
+    display: inline-block; padding: 1px 7px; border-radius: 4px;
     font-size: 10px; background: var(--gray-100); color: var(--gray-600);
   }
 
-  /* Filter bar */
-  .filter-bar {
+  /* Filter + pager bar */
+  .bar {
     display: flex; align-items: center; gap: 8px; margin-bottom: 12px; flex-wrap: wrap;
   }
-  .filter-bar label { font-size: 10px; color: var(--gray-400); }
-  .filter-select {
+  .bar label { font-size: 10px; color: var(--gray-400); }
+  .bar-sep { width: 1px; height: 16px; background: var(--gray-200); margin: 0 4px; }
+  .fsel {
     font-family: inherit; font-size: 11px; color: var(--gray-700);
     background: var(--gray-50); border: 1px solid var(--gray-200);
     border-radius: 4px; padding: 3px 6px; outline: none; cursor: pointer;
   }
-  .filter-select:focus { border-color: var(--purple); }
-  .filter-input {
+  .fsel:focus { border-color: var(--purple); }
+  .finput {
     font-family: inherit; font-size: 11px; color: var(--gray-700);
     background: var(--gray-50); border: 1px solid var(--gray-200);
     border-radius: 4px; padding: 3px 8px; outline: none; width: 180px;
   }
-  .filter-input:focus { border-color: var(--purple); }
-  .filter-btn {
+  .finput:focus { border-color: var(--purple); }
+  .fbtn {
     font-family: inherit; font-size: 10px; padding: 3px 10px;
     border: 1px solid var(--gray-200); border-radius: 4px;
     background: var(--gray-50); color: var(--gray-500); cursor: pointer;
   }
-  .filter-btn.active { background: var(--gray-800); color: #fff; border-color: var(--gray-800); }
-  .filter-count { font-size: 10px; color: var(--gray-400); margin-left: auto; }
+  .fbtn.active { background: var(--gray-800); color: #fff; border-color: var(--gray-800); }
+  .bar-right { margin-left: auto; display: flex; align-items: center; gap: 8px; }
+  .result-count { font-size: 10px; color: var(--gray-400); }
+
+  /* Pagination */
+  .pager {
+    display: flex; align-items: center; gap: 6px; margin-top: 12px;
+    padding-top: 12px; border-top: 1px solid var(--gray-100);
+  }
+  .pg-btn {
+    font-family: inherit; font-size: 11px; padding: 3px 10px;
+    border: 1px solid var(--gray-200); border-radius: 4px;
+    background: #fff; color: var(--gray-700); cursor: pointer;
+  }
+  .pg-btn:disabled { opacity: 0.35; cursor: default; }
+  .pg-btn:not(:disabled):hover { background: var(--gray-50); }
+  .pg-nums { display: flex; gap: 4px; }
+  .pg-num {
+    font-family: inherit; font-size: 11px; min-width: 28px; padding: 3px 6px;
+    border: 1px solid transparent; border-radius: 4px;
+    background: none; color: var(--gray-500); cursor: pointer; text-align: center;
+  }
+  .pg-num.cur { background: var(--gray-800); color: #fff; border-color: var(--gray-800); cursor: default; }
+  .pg-num:not(.cur):hover { background: var(--gray-50); border-color: var(--gray-200); }
+  .pg-num.ellipsis { cursor: default; pointer-events: none; }
+  .pg-info { font-size: 10px; color: var(--gray-400); margin-left: 4px; }
+  .pg-limit { font-family: inherit; font-size: 11px; padding: 3px 6px;
+              border: 1px solid var(--gray-200); border-radius: 4px;
+              background: var(--gray-50); color: var(--gray-700); cursor: pointer;
+              margin-left: auto; }
 
   /* Live events */
   .event-row {
@@ -168,22 +207,22 @@
   /* Findings drilldown */
   .finding-row { cursor: pointer; }
   .finding-row:hover td { background: var(--gray-50); }
-  .finding-evidence-row { display: none; }
-  .finding-evidence-row.open { display: table-row; }
-  .finding-evidence-cell {
+  .finding-ev-row { display: none; }
+  .finding-ev-row.open { display: table-row; }
+  .finding-ev-cell {
     padding: 8px 12px 12px; background: var(--gray-50);
     font-size: 11px; color: var(--gray-600); line-height: 1.6;
   }
-  .finding-command {
+  .finding-cmd {
     margin-top: 6px; padding: 6px 8px;
     background: var(--gray-900); color: #e5e7eb;
     border-radius: 4px; font-size: 10px; word-break: break-all;
   }
-  .finding-command:empty { display: none; }
-  .sort-indicator { font-size: 9px; margin-left: 2px; opacity: 0.5; }
+  .finding-cmd:empty { display: none; }
+  .expand-arrow { font-size: 9px; color: var(--gray-300); }
 
   /* Empty state */
-  .empty-state { padding: 24px; text-align: center; font-size: 11px; color: var(--gray-400); }
+  .empty { padding: 24px; text-align: center; font-size: 11px; color: var(--gray-400); }
 
   @media (max-width: 768px) {
     .grid-4, .grid-3, .grid-2, .grid-1-2 { grid-template-columns: 1fr; }
@@ -221,38 +260,22 @@
 
 <!-- Severity Strip -->
 <div class="grid grid-4">
-  <div class="card sev-card critical">
-    <div class="sev-label">Critical</div>
-    <div id="sevCritical" class="sev-count">-</div>
-  </div>
-  <div class="card sev-card high">
-    <div class="sev-label">High</div>
-    <div id="sevHigh" class="sev-count">-</div>
-  </div>
-  <div class="card sev-card medium">
-    <div class="sev-label">Medium</div>
-    <div id="sevMedium" class="sev-count">-</div>
-  </div>
-  <div class="card sev-card low">
-    <div class="sev-label">Low</div>
-    <div id="sevLow" class="sev-count">-</div>
-  </div>
+  <div class="card sev-card critical"><div class="sev-label">Critical</div><div id="sevCritical" class="sev-count">-</div></div>
+  <div class="card sev-card high">    <div class="sev-label">High</div>    <div id="sevHigh"     class="sev-count">-</div></div>
+  <div class="card sev-card medium">  <div class="sev-label">Medium</div>  <div id="sevMedium"   class="sev-count">-</div></div>
+  <div class="card sev-card low">     <div class="sev-label">Low</div>     <div id="sevLow"      class="sev-count">-</div></div>
 </div>
 
 <!-- Row 1: Threats Donut + Block Rate Line -->
 <div class="grid grid-1-2">
   <div class="card">
     <div class="card-title">Threats by Category</div>
-    <div class="chart-container" style="height:190px">
-      <canvas id="donutChart"></canvas>
-    </div>
+    <div class="chart-container" style="height:190px"><canvas id="donutChart"></canvas></div>
     <div id="donutLegend" class="legend-grid"></div>
   </div>
   <div class="card">
     <div class="card-title">Block Rate &mdash; 30 days</div>
-    <div class="chart-container" style="height:240px">
-      <canvas id="lineChart"></canvas>
-    </div>
+    <div class="chart-container" style="height:240px"><canvas id="lineChart"></canvas></div>
   </div>
 </div>
 
@@ -260,15 +283,11 @@
 <div class="grid grid-2">
   <div class="card">
     <div class="card-title">Blocked Commands by Agent</div>
-    <div class="chart-container" style="height:200px">
-      <canvas id="agentBar"></canvas>
-    </div>
+    <div class="chart-container" style="height:200px"><canvas id="agentBar"></canvas></div>
   </div>
   <div class="card">
     <div class="card-title">Tool Call Breakdown</div>
-    <div class="chart-container" style="height:200px">
-      <canvas id="toolBar"></canvas>
-    </div>
+    <div class="chart-container" style="height:200px"><canvas id="toolBar"></canvas></div>
   </div>
 </div>
 
@@ -276,29 +295,42 @@
 <div class="grid" style="grid-template-columns:1fr">
   <div class="card">
     <div class="card-title">Top MCP Servers &amp; Skills</div>
-    <div class="chart-container" style="height:220px">
-      <canvas id="mcpBar"></canvas>
-    </div>
+    <div class="chart-container" style="height:220px"><canvas id="mcpBar"></canvas></div>
   </div>
 </div>
 
-<!-- Row 4: Recent Sessions -->
+<!-- Row 4: Sessions (paginated) -->
 <div class="grid" style="grid-template-columns:1fr">
   <div class="card">
-    <div class="card-title">Recent Sessions</div>
+    <div class="card-title">Sessions</div>
+    <div class="bar">
+      <span id="sessCount" class="result-count"></span>
+      <div class="bar-right">
+        <label>Per page</label>
+        <select id="sessLimit" class="fsel">
+          <option value="10">10</option>
+          <option value="20" selected>20</option>
+          <option value="50">50</option>
+          <option value="100">100</option>
+        </select>
+      </div>
+    </div>
     <div style="overflow-x:auto">
-      <table id="sessionsTable">
-        <thead><tr>
-          <th data-col="sessionId">Session<span class="sort-indicator">↕</span></th>
-          <th data-col="agent">Agent<span class="sort-indicator">↕</span></th>
-          <th data-col="workspace">Workspace<span class="sort-indicator">↕</span></th>
-          <th data-col="riskScore">Risk Score<span class="sort-indicator">↕</span></th>
-          <th data-col="findingsCount" class="right">Findings<span class="sort-indicator">↕</span></th>
-          <th data-col="updatedAt">Last Active<span class="sort-indicator">↕</span></th>
-        </tr></thead>
-        <tbody id="sessionsBody"></tbody>
+      <table>
+        <thead id="sessThead">
+          <tr>
+            <th data-col="sessionId">Session<span class="sort-ind">↕</span></th>
+            <th data-col="agent">Agent<span class="sort-ind">↕</span></th>
+            <th data-col="workspace">Workspace<span class="sort-ind">↕</span></th>
+            <th data-col="riskScore">Risk Score<span class="sort-ind">↕</span></th>
+            <th data-col="findingsCount" class="right">Findings<span class="sort-ind">↕</span></th>
+            <th data-col="updatedAt">Last Active<span class="sort-ind">↕</span></th>
+          </tr>
+        </thead>
+        <tbody id="sessBody"></tbody>
       </table>
     </div>
+    <div id="sessPager" class="pager"></div>
   </div>
 </div>
 
@@ -321,15 +353,15 @@
   </div>
 </div>
 
-<!-- Row 6: Findings Drilldown -->
+<!-- Row 6: Findings Drilldown (paginated) -->
 <div class="grid" style="grid-template-columns:1fr">
   <div class="card">
     <div class="card-title">Findings Drilldown</div>
-    <div class="filter-bar">
+    <div class="bar">
       <label>Agent</label>
-      <select id="fAgent" class="filter-select"><option value="">All</option></select>
+      <select id="fAgent" class="fsel"><option value="">All</option></select>
       <label>Severity</label>
-      <select id="fSeverity" class="filter-select">
+      <select id="fSev" class="fsel">
         <option value="">All</option>
         <option value="critical">Critical</option>
         <option value="high">High</option>
@@ -337,34 +369,55 @@
         <option value="low">Low</option>
       </select>
       <label>Category</label>
-      <select id="fCategory" class="filter-select"><option value="">All</option></select>
-      <input id="fSearch" class="filter-input" type="text" placeholder="search title or command…" />
-      <span id="findingsCount" class="filter-count"></span>
+      <select id="fCat" class="fsel"><option value="">All</option></select>
+      <input id="fSearch" class="finput" type="text" placeholder="search title or evidence…" />
+      <div class="bar-right">
+        <span id="findCount" class="result-count"></span>
+        <label>Per page</label>
+        <select id="findLimit" class="fsel">
+          <option value="10">10</option>
+          <option value="25" selected>25</option>
+          <option value="50">50</option>
+          <option value="100">100</option>
+        </select>
+      </div>
     </div>
     <div style="overflow-x:auto">
       <table>
         <thead><tr>
           <th>Finding</th><th>Agent</th><th>Category</th><th>Severity</th><th>When</th><th style="width:16px"></th>
         </tr></thead>
-        <tbody id="findingsBody"></tbody>
+        <tbody id="findBody"></tbody>
       </table>
     </div>
+    <div id="findPager" class="pager"></div>
   </div>
 </div>
 
-<!-- Row 7: Live Event Feed -->
+<!-- Row 7: Events Feed (paginated) -->
 <div class="grid" style="grid-template-columns:1fr">
   <div class="card">
-    <div class="card-title">Live Event Feed</div>
-    <div class="filter-bar">
-      <button class="filter-btn active" data-verdict="">All</button>
-      <button class="filter-btn" data-verdict="blocked">Blocked</button>
-      <button class="filter-btn" data-verdict="allowed">Allowed</button>
-      <label style="margin-left:8px">Agent</label>
-      <select id="eAgent" class="filter-select"><option value="">All</option></select>
-      <span id="eventsCount" class="filter-count"></span>
+    <div class="card-title">Event Feed</div>
+    <div class="bar">
+      <button class="fbtn active" data-verdict="">All</button>
+      <button class="fbtn" data-verdict="blocked">Blocked</button>
+      <button class="fbtn" data-verdict="allowed">Allowed</button>
+      <div class="bar-sep"></div>
+      <label>Agent</label>
+      <select id="evtAgent" class="fsel"><option value="">All</option></select>
+      <div class="bar-right">
+        <span id="evtCount" class="result-count"></span>
+        <label>Per page</label>
+        <select id="evtLimit" class="fsel">
+          <option value="20">20</option>
+          <option value="30" selected>30</option>
+          <option value="50">50</option>
+          <option value="100">100</option>
+        </select>
+      </div>
     </div>
-    <div id="eventsContainer"></div>
+    <div id="evtContainer"></div>
+    <div id="evtPager" class="pager"></div>
   </div>
 </div>
 
@@ -376,10 +429,11 @@ const CAT_LABELS = {
   malicious_mcp: 'Malicious MCP', dangerous_command: 'Dangerous Cmd',
 };
 
+// XSS-safe text injection
 function safe(s) {
-  const d = document.createElement('span');
-  d.textContent = String(s || '');
-  return d.outerHTML;
+  const el = document.createElement('span');
+  el.textContent = String(s || '');
+  return el.outerHTML;
 }
 
 function fmtNum(n) {
@@ -396,13 +450,46 @@ function riskClass(n) {
   return 'risk-0';
 }
 
-// ── State ────────────────────────────────────────────────────────────────────
-let _allFindings = [];
-let _allEvents = [];
-let _sessionsData = [];
-let _sessionsSort = { col: 'updatedAt', dir: -1 };
-let _evtVerdict = '';
-let _evtAgent = '';
+// ── Pager builder ────────────────────────────────────────────────────────────
+function buildPager(containerId, state, loadFn) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+  if (state.pages <= 1 && state.total === 0) { container.innerHTML = ''; return; }
+
+  const { page, pages, total, limit } = state;
+  const from = total === 0 ? 0 : (page - 1) * limit + 1;
+  const to   = Math.min(page * limit, total);
+
+  // Build page number list with ellipsis
+  const nums = [];
+  for (let i = 1; i <= pages; i++) {
+    if (i === 1 || i === pages || (i >= page - 2 && i <= page + 2)) {
+      nums.push(i);
+    } else if (nums[nums.length - 1] !== '…') {
+      nums.push('…');
+    }
+  }
+
+  container.innerHTML =
+    '<button class="pg-btn" id="' + containerId + 'Prev"' + (page <= 1 ? ' disabled' : '') + '>← Prev</button>' +
+    '<div class="pg-nums">' + nums.map(n =>
+      n === '…'
+        ? '<span class="pg-num ellipsis">…</span>'
+        : '<button class="pg-num' + (n === page ? ' cur' : '') + '" data-p="' + n + '">' + n + '</button>'
+    ).join('') + '</div>' +
+    '<button class="pg-btn" id="' + containerId + 'Next"' + (page >= pages ? ' disabled' : '') + '>Next →</button>' +
+    '<span class="pg-info">' + from + '–' + to + ' of ' + fmtNum(total) + '</span>';
+
+  container.querySelector('#' + containerId + 'Prev')
+    ?.addEventListener('click', () => { state.page--; loadFn(); });
+  container.querySelector('#' + containerId + 'Next')
+    ?.addEventListener('click', () => { state.page++; loadFn(); });
+  container.querySelectorAll('.pg-num:not(.cur):not(.ellipsis)')
+    .forEach(btn => btn.addEventListener('click', () => {
+      state.page = parseInt(btn.dataset.p, 10);
+      loadFn();
+    }));
+}
 
 // ── Chart instances ──────────────────────────────────────────────────────────
 let donutChart, lineChart, agentBarChart, toolBarChart, mcpBarChart;
@@ -415,17 +502,14 @@ function initCharts() {
   donutChart = new Chart(document.getElementById('donutChart'), {
     type: 'doughnut',
     data: { labels: [], datasets: [{ data: [], backgroundColor: COLORS, borderWidth: 0 }] },
-    options: {
-      cutout: '60%', responsive: true, maintainAspectRatio: false,
-      plugins: { legend: { display: false } },
-    },
+    options: { cutout: '60%', responsive: true, maintainAspectRatio: false, plugins: { legend: { display: false } } },
   });
 
   lineChart = new Chart(document.getElementById('lineChart'), {
     type: 'line',
     data: { labels: [], datasets: [
-      { label: 'Passed', data: [], borderColor: '#CBD5E1', borderWidth: 1.5, pointRadius: 0, tension: 0.3 },
-      { label: 'Intercepted', data: [], borderColor: '#E8BAEE', borderWidth: 2, pointRadius: 0, tension: 0.3 },
+      { label: 'Passed',      data: [], borderColor: '#CBD5E1', borderWidth: 1.5, pointRadius: 0, tension: 0.3 },
+      { label: 'Intercepted', data: [], borderColor: '#E8BAEE', borderWidth: 2,   pointRadius: 0, tension: 0.3 },
     ]},
     options: {
       responsive: true, maintainAspectRatio: false,
@@ -461,7 +545,7 @@ function initCharts() {
     type: 'bar',
     data: { labels: [], datasets: [
       { label: 'Total Calls', data: [], backgroundColor: '#A8D5F7', borderRadius: 4, barThickness: 18 },
-      { label: 'Blocked', data: [], backgroundColor: '#E8BAEE', borderRadius: 4, barThickness: 18 },
+      { label: 'Blocked',     data: [], backgroundColor: '#E8BAEE', borderRadius: 4, barThickness: 18 },
     ]},
     options: {
       responsive: true, maintainAspectRatio: false,
@@ -471,93 +555,115 @@ function initCharts() {
   });
 }
 
-// ── Sessions table ───────────────────────────────────────────────────────────
-function renderSessions() {
-  const rows = [..._sessionsData].sort((a, b) => {
-    let av = a[_sessionsSort.col], bv = b[_sessionsSort.col];
-    if (typeof av === 'number') return _sessionsSort.dir * (av - bv);
-    return _sessionsSort.dir * String(av || '').localeCompare(String(bv || ''));
-  });
+// ── Sessions ─────────────────────────────────────────────────────────────────
+const sessState = { page: 1, limit: 20, sort: 'updatedAt', dir: 'desc', total: 0, pages: 1 };
 
-  const tbody = document.getElementById('sessionsBody');
-  if (!rows.length) {
-    tbody.innerHTML = '<tr><td colspan="6" class="empty-state">No sessions yet</td></tr>';
-    return;
-  }
+async function loadSessions() {
+  const { page, limit, sort, dir } = sessState;
+  try {
+    const res = await fetch(`/api/sessions?page=${page}&limit=${limit}&sort=${sort}&dir=${dir}`);
+    const data = await res.json();
+    sessState.page = data.page; sessState.pages = data.pages; sessState.total = data.total;
+    renderSessions(data.items);
+    buildPager('sessPager', sessState, loadSessions);
+    document.getElementById('sessCount').textContent = fmtNum(data.total) + ' sessions';
+    updateSessHeaders();
+  } catch (e) { console.error('[warden] sessions fetch failed:', e); }
+}
+
+function renderSessions(rows) {
+  const tbody = document.getElementById('sessBody');
+  if (!rows.length) { tbody.innerHTML = '<tr><td colspan="6" class="empty">No sessions yet</td></tr>'; return; }
   tbody.innerHTML = rows.map(s => {
     const rc = riskClass(s.riskScore);
-    const hasFi = s.findingsCount > 0;
     return '<tr>' +
       '<td class="mono">' + safe(s.sessionId) + '</td>' +
       '<td><span class="agent-pill">' + safe(s.agent) + '</span></td>' +
       '<td style="color:var(--gray-500)">' + safe(s.workspace) + '</td>' +
-      '<td><div class="risk-bar-wrap"><div class="risk-bar"><div class="risk-bar-fill ' + rc + '" style="width:' + s.riskScore + '%"></div></div><span class="risk-num">' + s.riskScore + '</span></div></td>' +
-      '<td class="right" style="' + (hasFi ? 'color:var(--pink-600);font-weight:600' : '') + '">' + s.findingsCount + '</td>' +
+      '<td><div class="risk-wrap"><div class="risk-bar"><div class="risk-fill ' + rc + '" style="width:' + s.riskScore + '%"></div></div><span class="risk-num">' + s.riskScore + '</span></div></td>' +
+      '<td class="right"' + (s.findingsCount > 0 ? ' style="color:var(--pink-600);font-weight:600"' : '') + '>' + s.findingsCount + '</td>' +
       '<td style="color:var(--gray-400)">' + safe(s.updatedAt) + '</td>' +
     '</tr>';
   }).join('');
 }
 
-document.getElementById('sessionsTable').querySelector('thead').addEventListener('click', e => {
+function updateSessHeaders() {
+  document.querySelectorAll('#sessThead th[data-col]').forEach(th => {
+    th.classList.toggle('active-sort', th.dataset.col === sessState.sort);
+    const ind = th.querySelector('.sort-ind');
+    if (ind) ind.textContent = th.dataset.col === sessState.sort ? (sessState.dir === 'asc' ? '↑' : '↓') : '↕';
+  });
+}
+
+document.getElementById('sessThead').addEventListener('click', e => {
   const th = e.target.closest('th[data-col]');
   if (!th) return;
   const col = th.dataset.col;
-  _sessionsSort.dir = (_sessionsSort.col === col) ? -_sessionsSort.dir : -1;
-  _sessionsSort.col = col;
-  renderSessions();
+  sessState.dir = (sessState.sort === col && sessState.dir === 'desc') ? 'asc' : 'desc';
+  sessState.sort = col;
+  sessState.page = 1;
+  loadSessions();
 });
 
-// ── Findings drilldown ───────────────────────────────────────────────────────
-function populateFindingFilters(findings) {
-  const agents = [...new Set(findings.map(f => f.agent))].sort();
-  const cats = [...new Set(findings.map(f => f.category))].sort();
+document.getElementById('sessLimit').addEventListener('change', e => {
+  sessState.limit = parseInt(e.target.value, 10);
+  sessState.page = 1;
+  loadSessions();
+});
 
-  const fAgent = document.getElementById('fAgent');
-  const cur = fAgent.value;
-  fAgent.innerHTML = '<option value="">All</option>' +
-    agents.map(a => '<option value="' + a + '"' + (a === cur ? ' selected' : '') + '>' + a + '</option>').join('');
+// ── Findings ─────────────────────────────────────────────────────────────────
+const findState = { page: 1, limit: 25, agent: '', severity: '', category: '', q: '', total: 0, pages: 1 };
+let _findAgents = [], _findCats = [];
 
-  const fCat = document.getElementById('fCategory');
-  const curC = fCat.value;
-  fCat.innerHTML = '<option value="">All</option>' +
-    cats.map(c => '<option value="' + c + '"' + (c === curC ? ' selected' : '') + '>' + (CAT_LABELS[c] || c) + '</option>').join('');
+async function loadFindings() {
+  const { page, limit, agent, severity, category, q } = findState;
+  const params = new URLSearchParams({ page, limit, agent, severity, category, q });
+  try {
+    const res = await fetch('/api/findings?' + params);
+    const data = await res.json();
+    findState.page = data.page; findState.pages = data.pages; findState.total = data.total;
+
+    // Populate filter dropdowns (preserve selections)
+    if (data.agents) {
+      _findAgents = data.agents;
+      const sel = document.getElementById('fAgent');
+      const cur = sel.value;
+      sel.innerHTML = '<option value="">All</option>' + data.agents.map(a =>
+        '<option value="' + a + '"' + (a === cur ? ' selected' : '') + '>' + a + '</option>'
+      ).join('');
+    }
+    if (data.categories) {
+      _findCats = data.categories;
+      const sel = document.getElementById('fCat');
+      const cur = sel.value;
+      sel.innerHTML = '<option value="">All</option>' + data.categories.map(c =>
+        '<option value="' + c + '"' + (c === cur ? ' selected' : '') + '>' + (CAT_LABELS[c] || c) + '</option>'
+      ).join('');
+    }
+
+    renderFindings(data.items);
+    buildPager('findPager', findState, loadFindings);
+    document.getElementById('findCount').textContent = fmtNum(data.total) + ' findings';
+  } catch (e) { console.error('[warden] findings fetch failed:', e); }
 }
 
-function renderFindings() {
-  const agent = document.getElementById('fAgent').value;
-  const severity = document.getElementById('fSeverity').value;
-  const category = document.getElementById('fCategory').value;
-  const search = document.getElementById('fSearch').value.toLowerCase();
-
-  const filtered = _allFindings.filter(f =>
-    (!agent || f.agent === agent) &&
-    (!severity || f.severity === severity) &&
-    (!category || f.category === category) &&
-    (!search || f.title.toLowerCase().includes(search) || (f.command || '').toLowerCase().includes(search))
-  );
-
-  document.getElementById('findingsCount').textContent = filtered.length + ' of ' + _allFindings.length;
-
-  const tbody = document.getElementById('findingsBody');
-  if (!filtered.length) {
-    tbody.innerHTML = '<tr><td colspan="6" class="empty-state">No findings match the current filters</td></tr>';
-    return;
-  }
-
-  tbody.innerHTML = filtered.map((f, i) => {
-    const eid = 'fe-' + i;
+function renderFindings(rows) {
+  const tbody = document.getElementById('findBody');
+  if (!rows.length) { tbody.innerHTML = '<tr><td colspan="6" class="empty">No findings match the current filters</td></tr>'; return; }
+  tbody.innerHTML = rows.map((f, i) => {
+    const eid = 'fev-' + i;
     return '<tr class="finding-row" onclick="toggleEvidence(\'' + eid + '\')">' +
       '<td>' + safe(f.title) + '</td>' +
       '<td><span class="agent-pill">' + safe(f.agent) + '</span></td>' +
       '<td style="color:var(--gray-500)">' + safe(CAT_LABELS[f.category] || f.category) + '</td>' +
       '<td><span class="sev-badge ' + sevClass(f.severity) + '">' + safe(f.severity) + '</span></td>' +
       '<td style="color:var(--gray-400)">' + safe(f.ts) + '</td>' +
-      '<td style="color:var(--gray-300);font-size:9px">▸</td>' +
+      '<td class="expand-arrow">▸</td>' +
     '</tr>' +
-    '<tr id="' + eid + '" class="finding-evidence-row">' +
-      '<td class="finding-evidence-cell" colspan="6">' +
+    '<tr id="' + eid + '" class="finding-ev-row">' +
+      '<td class="finding-ev-cell" colspan="6">' +
         '<div>' + safe(f.evidence || 'No evidence recorded.') + '</div>' +
-        '<div class="finding-command">' + safe(f.command) + '</div>' +
+        '<div class="finding-cmd">' + safe(f.command) + '</div>' +
         '<div style="margin-top:6px;font-size:10px;color:var(--gray-400)">session: ' + safe(f.sessionId) + '</div>' +
       '</td>' +
     '</tr>';
@@ -568,39 +674,60 @@ function toggleEvidence(id) {
   const row = document.getElementById(id);
   if (!row) return;
   row.classList.toggle('open');
-  const arrow = row.previousElementSibling.querySelector('td:last-child');
-  if (arrow) arrow.textContent = row.classList.contains('open') ? '▾' : '▸';
-}
-
-['fAgent','fSeverity','fCategory'].forEach(id =>
-  document.getElementById(id).addEventListener('change', renderFindings)
-);
-document.getElementById('fSearch').addEventListener('input', renderFindings);
-
-// ── Live event feed ──────────────────────────────────────────────────────────
-function populateEventAgents(events) {
-  const agents = [...new Set(events.map(e => e.agent))].sort();
-  const sel = document.getElementById('eAgent');
-  const cur = sel.value;
-  sel.innerHTML = '<option value="">All</option>' +
-    agents.map(a => '<option value="' + a + '"' + (a === cur ? ' selected' : '') + '>' + a + '</option>').join('');
-}
-
-function renderEvents() {
-  const filtered = _allEvents.filter(ev =>
-    (!_evtVerdict || ev.verdict === _evtVerdict) &&
-    (!_evtAgent || ev.agent === _evtAgent)
-  );
-
-  document.getElementById('eventsCount').textContent = filtered.length + ' events';
-
-  const container = document.getElementById('eventsContainer');
-  if (!filtered.length) {
-    container.innerHTML = '<div class="empty-state">No events match the current filters</div>';
-    return;
+  const prev = row.previousElementSibling;
+  if (prev) {
+    const arrow = prev.querySelector('.expand-arrow');
+    if (arrow) arrow.textContent = row.classList.contains('open') ? '▾' : '▸';
   }
+}
 
-  container.innerHTML = filtered.slice(0, 30).map(ev =>
+['fAgent','fSev','fCat'].forEach(id => document.getElementById(id).addEventListener('change', e => {
+  findState[id === 'fAgent' ? 'agent' : id === 'fSev' ? 'severity' : 'category'] = e.target.value;
+  findState.page = 1;
+  loadFindings();
+}));
+
+let _findSearchTimer;
+document.getElementById('fSearch').addEventListener('input', e => {
+  clearTimeout(_findSearchTimer);
+  _findSearchTimer = setTimeout(() => { findState.q = e.target.value; findState.page = 1; loadFindings(); }, 300);
+});
+
+document.getElementById('findLimit').addEventListener('change', e => {
+  findState.limit = parseInt(e.target.value, 10);
+  findState.page = 1;
+  loadFindings();
+});
+
+// ── Events ───────────────────────────────────────────────────────────────────
+const evtState = { page: 1, limit: 30, verdict: '', agent: '', total: 0, pages: 1 };
+
+async function loadEvents() {
+  const { page, limit, verdict, agent } = evtState;
+  const params = new URLSearchParams({ page, limit, verdict, agent });
+  try {
+    const res = await fetch('/api/events?' + params);
+    const data = await res.json();
+    evtState.page = data.page; evtState.pages = data.pages; evtState.total = data.total;
+
+    if (data.agents) {
+      const sel = document.getElementById('evtAgent');
+      const cur = sel.value;
+      sel.innerHTML = '<option value="">All</option>' + data.agents.map(a =>
+        '<option value="' + a + '"' + (a === cur ? ' selected' : '') + '>' + a + '</option>'
+      ).join('');
+    }
+
+    renderEvents(data.items);
+    buildPager('evtPager', evtState, loadEvents);
+    document.getElementById('evtCount').textContent = fmtNum(data.total) + ' events';
+  } catch (e) { console.error('[warden] events fetch failed:', e); }
+}
+
+function renderEvents(rows) {
+  const container = document.getElementById('evtContainer');
+  if (!rows.length) { container.innerHTML = '<div class="empty">No events match the current filters</div>'; return; }
+  container.innerHTML = rows.map(ev =>
     '<div class="event-row">' +
       '<span class="event-dot ' + (ev.verdict || 'allowed') + '"></span>' +
       '<div style="flex:1;min-width:0">' +
@@ -612,148 +739,147 @@ function renderEvents() {
   ).join('');
 }
 
-document.querySelectorAll('.filter-btn[data-verdict]').forEach(btn => {
+document.querySelectorAll('.fbtn[data-verdict]').forEach(btn => {
   btn.addEventListener('click', () => {
-    document.querySelectorAll('.filter-btn[data-verdict]').forEach(b => b.classList.remove('active'));
+    document.querySelectorAll('.fbtn[data-verdict]').forEach(b => b.classList.remove('active'));
     btn.classList.add('active');
-    _evtVerdict = btn.dataset.verdict;
-    renderEvents();
+    evtState.verdict = btn.dataset.verdict;
+    evtState.page = 1;
+    loadEvents();
   });
 });
 
-document.getElementById('eAgent').addEventListener('change', e => {
-  _evtAgent = e.target.value;
-  renderEvents();
+document.getElementById('evtAgent').addEventListener('change', e => {
+  evtState.agent = e.target.value;
+  evtState.page = 1;
+  loadEvents();
 });
 
-// ── Main update ──────────────────────────────────────────────────────────────
-function updateDashboard(data) {
-  // Badge + timestamp
-  const badge = document.getElementById('statusBadge');
-  const hasData = data.kpis && data.kpis.toolCallsInspected24h > 0;
-  badge.className = 'badge ' + (hasData ? 'badge-live' : 'badge-demo');
-  badge.innerHTML = '<span class="badge-dot"></span> ' + (hasData ? 'live' : 'no data');
-  document.getElementById('lastUpdated').textContent = 'updated ' + new Date().toLocaleTimeString();
+document.getElementById('evtLimit').addEventListener('change', e => {
+  evtState.limit = parseInt(e.target.value, 10);
+  evtState.page = 1;
+  loadEvents();
+});
 
-  // KPIs
-  const k = data.kpis || {};
-  document.getElementById('kpiSessions').textContent = fmtNum(k.activeSessions || 0);
-  document.getElementById('kpiToolCalls').textContent = fmtNum(k.toolCallsInspected24h || 0);
-  document.getElementById('kpiDangerous').textContent = fmtNum(k.dangerousCommandsPrevented24h || 0);
-
-  const d = k.deltas || {};
-  const toolsDelta = document.getElementById('kpiToolsDelta');
-  if (d.tools !== undefined) {
-    const cls = d.tools > 0 ? 'up' : 'down';
-    toolsDelta.innerHTML = '<span class="' + cls + '">' + (d.tools > 0 ? '+' : '') + d.tools + '%</span> vs yesterday';
-  }
-  const dangDelta = document.getElementById('kpiDangerousDelta');
-  if (d.dangerous !== undefined) {
-    const cls = d.dangerous > 0 ? 'up' : 'down';
-    dangDelta.innerHTML = '<span class="' + cls + '">' + (d.dangerous > 0 ? '+' : '') + d.dangerous + '%</span> vs yesterday';
-  }
-
-  // Severity strip
-  const sv = data.severityBreakdown || {};
-  document.getElementById('sevCritical').textContent = fmtNum(sv.critical || 0);
-  document.getElementById('sevHigh').textContent = fmtNum(sv.high || 0);
-  document.getElementById('sevMedium').textContent = fmtNum(sv.medium || 0);
-  document.getElementById('sevLow').textContent = fmtNum(sv.low || 0);
-
-  // Donut
-  const threats = data.threatsByCategory || {};
-  const catKeys = Object.keys(CAT_LABELS);
-  donutChart.data.labels = catKeys.map(k => CAT_LABELS[k]);
-  donutChart.data.datasets[0].data = catKeys.map(k => threats[k] || 0);
-  donutChart.update();
-
-  const legendEl = document.getElementById('donutLegend');
-  legendEl.innerHTML = catKeys.map((k, i) =>
-    '<div class="legend-item"><span class="legend-dot" style="background:' + COLORS[i] + '"></span>' + CAT_LABELS[k] + '</div>'
-  ).join('');
-
-  // Line chart
-  const ts = data.blockRateTimeseries || [];
-  lineChart.data.labels = ts.map(t => t.date);
-  lineChart.data.datasets[0].data = ts.map(t => t.passed);
-  lineChart.data.datasets[1].data = ts.map(t => t.intercepted);
-  lineChart.update();
-
-  // Agent bar
-  const ab = data.agentBlockedCommands || [];
-  agentBarChart.data.labels = ab.map(a => a.agent);
-  agentBarChart.data.datasets[0].data = ab.map(a => a.blocked);
-  agentBarChart.update();
-
-  // Tool bar
-  const tb = data.toolCallBreakdown || [];
-  toolBarChart.data.labels = tb.map(t => t.tool);
-  toolBarChart.data.datasets[0].data = tb.map(t => t.count);
-  toolBarChart.update();
-
-  // MCP bar
-  const mcp = data.topMcpAndSkills || [];
-  mcpBarChart.data.labels = mcp.map(m => m.name);
-  mcpBarChart.data.datasets[0].data = mcp.map(m => m.calls);
-  mcpBarChart.data.datasets[1].data = mcp.map(m => m.blocked);
-  mcpBarChart.update();
-
-  // Sessions
-  _sessionsData = data.recentSessions || [];
-  renderSessions();
-
-  // Top users
-  const users = data.topUsersByBlocks || [];
-  const maxBlocked = users.length > 0 ? users[0].blocked : 1;
-  document.getElementById('usersContainer').innerHTML = users.map((u, i) =>
-    '<div class="user-row">' +
-      '<span class="user-rank">' + (i + 1) + '</span>' +
-      '<div class="user-info">' +
-        '<div class="user-top"><span class="user-id">' + safe(u.userId) + '</span>' +
-        '<span class="user-count">' + u.blocked + '</span></div>' +
-        '<div class="user-bar"><div class="user-bar-fill" style="width:' + (u.blocked / maxBlocked * 100) + '%"></div></div>' +
-      '</div>' +
-      '<span class="user-seen">' + safe(u.lastSeen || '') + '</span>' +
-    '</div>'
-  ).join('');
-
-  // Threat patterns
-  const patterns = data.topPatterns || [];
-  document.getElementById('patternsBody').innerHTML = patterns.map(p =>
-    '<tr>' +
-      '<td>' + safe(p.pattern || '') + '</td>' +
-      '<td style="color:#9ca3af">' + safe(CAT_LABELS[p.category] || p.category) + '</td>' +
-      '<td class="right" style="font-weight:500">' + (p.count || 0) + '</td>' +
-      '<td style="color:#9ca3af">' + safe(p.lastSeen || '') + '</td>' +
-      '<td><span class="sev-badge ' + sevClass(p.severity) + '">' + safe(p.severity || 'low') + '</span></td>' +
-    '</tr>'
-  ).join('');
-
-  // Findings drilldown
-  _allFindings = data.recentFindings || [];
-  populateFindingFilters(_allFindings);
-  renderFindings();
-
-  // Live events
-  _allEvents = data.liveEvents || [];
-  populateEventAgents(_allEvents);
-  renderEvents();
-}
-
-async function fetchStats() {
+// ── Stats (charts + KPIs) ────────────────────────────────────────────────────
+async function loadStats() {
   try {
     const res = await fetch('/api/stats');
     if (!res.ok) return;
     const data = await res.json();
-    updateDashboard(data);
-  } catch (e) {
-    console.error('[warden] fetch failed:', e);
-  }
+
+    // Badge
+    const badge = document.getElementById('statusBadge');
+    const hasData = data.kpis && data.kpis.toolCallsInspected24h > 0;
+    badge.className = 'badge ' + (hasData ? 'badge-live' : 'badge-demo');
+    badge.innerHTML = '<span class="badge-dot"></span> ' + (hasData ? 'live' : 'no data');
+    document.getElementById('lastUpdated').textContent = 'updated ' + new Date().toLocaleTimeString();
+
+    // KPIs
+    const k = data.kpis || {};
+    document.getElementById('kpiSessions').textContent = fmtNum(k.activeSessions || 0);
+    document.getElementById('kpiToolCalls').textContent = fmtNum(k.toolCallsInspected24h || 0);
+    document.getElementById('kpiDangerous').textContent = fmtNum(k.dangerousCommandsPrevented24h || 0);
+
+    const d = k.deltas || {};
+    if (d.tools !== undefined) {
+      const cls = d.tools > 0 ? 'up' : 'down';
+      document.getElementById('kpiToolsDelta').innerHTML =
+        '<span class="' + cls + '">' + (d.tools > 0 ? '+' : '') + d.tools + '%</span> vs yesterday';
+    }
+    if (d.dangerous !== undefined) {
+      const cls = d.dangerous > 0 ? 'up' : 'down';
+      document.getElementById('kpiDangerousDelta').innerHTML =
+        '<span class="' + cls + '">' + (d.dangerous > 0 ? '+' : '') + d.dangerous + '%</span> vs yesterday';
+    }
+
+    // Severity strip
+    const sv = data.severityBreakdown || {};
+    document.getElementById('sevCritical').textContent = fmtNum(sv.critical || 0);
+    document.getElementById('sevHigh').textContent     = fmtNum(sv.high     || 0);
+    document.getElementById('sevMedium').textContent   = fmtNum(sv.medium   || 0);
+    document.getElementById('sevLow').textContent      = fmtNum(sv.low      || 0);
+
+    // Donut
+    const threats = data.threatsByCategory || {};
+    const catKeys = Object.keys(CAT_LABELS);
+    donutChart.data.labels = catKeys.map(k => CAT_LABELS[k]);
+    donutChart.data.datasets[0].data = catKeys.map(k => threats[k] || 0);
+    donutChart.update();
+    document.getElementById('donutLegend').innerHTML = catKeys.map((k, i) =>
+      '<div class="legend-item"><span class="legend-dot" style="background:' + COLORS[i] + '"></span>' + CAT_LABELS[k] + '</div>'
+    ).join('');
+
+    // Line
+    const ts = data.blockRateTimeseries || [];
+    lineChart.data.labels = ts.map(t => t.date);
+    lineChart.data.datasets[0].data = ts.map(t => t.passed);
+    lineChart.data.datasets[1].data = ts.map(t => t.intercepted);
+    lineChart.update();
+
+    // Agent bar
+    const ab = data.agentBlockedCommands || [];
+    agentBarChart.data.labels = ab.map(a => a.agent);
+    agentBarChart.data.datasets[0].data = ab.map(a => a.blocked);
+    agentBarChart.update();
+
+    // Tool bar
+    const tb = data.toolCallBreakdown || [];
+    toolBarChart.data.labels = tb.map(t => t.tool);
+    toolBarChart.data.datasets[0].data = tb.map(t => t.count);
+    toolBarChart.update();
+
+    // MCP bar
+    const mcp = data.topMcpAndSkills || [];
+    mcpBarChart.data.labels = mcp.map(m => m.name);
+    mcpBarChart.data.datasets[0].data = mcp.map(m => m.calls);
+    mcpBarChart.data.datasets[1].data = mcp.map(m => m.blocked);
+    mcpBarChart.update();
+
+    // Top users
+    const users = data.topUsersByBlocks || [];
+    const maxBlocked = users.length > 0 ? users[0].blocked : 1;
+    document.getElementById('usersContainer').innerHTML = users.map((u, i) =>
+      '<div class="user-row">' +
+        '<span class="user-rank">' + (i + 1) + '</span>' +
+        '<div class="user-info">' +
+          '<div class="user-top"><span class="user-id">' + safe(u.userId) + '</span>' +
+          '<span class="user-count">' + u.blocked + '</span></div>' +
+          '<div class="user-bar"><div class="user-bar-fill" style="width:' + (u.blocked / maxBlocked * 100) + '%"></div></div>' +
+        '</div>' +
+        '<span class="user-seen">' + safe(u.lastSeen || '') + '</span>' +
+      '</div>'
+    ).join('');
+
+    // Threat patterns
+    const patterns = data.topPatterns || [];
+    document.getElementById('patternsBody').innerHTML = patterns.map(p =>
+      '<tr>' +
+        '<td>' + safe(p.pattern || '') + '</td>' +
+        '<td style="color:#9ca3af">' + safe(CAT_LABELS[p.category] || p.category) + '</td>' +
+        '<td class="right" style="font-weight:500">' + (p.count || 0) + '</td>' +
+        '<td style="color:#9ca3af">' + safe(p.lastSeen || '') + '</td>' +
+        '<td><span class="sev-badge ' + sevClass(p.severity) + '">' + safe(p.severity || 'low') + '</span></td>' +
+      '</tr>'
+    ).join('');
+  } catch (e) { console.error('[warden] stats fetch failed:', e); }
 }
 
+// ── Boot + poll ──────────────────────────────────────────────────────────────
 initCharts();
-fetchStats();
-setInterval(fetchStats, 30000);
+Promise.all([loadStats(), loadSessions(), loadFindings(), loadEvents()]);
+
+setInterval(() => {
+  loadStats();
+  loadSessions();
+  // Reload findings/events only if on page 1 with no active filters (avoid disrupting investigation)
+  if (findState.page === 1 && !findState.agent && !findState.severity && !findState.category && !findState.q) {
+    loadFindings();
+  }
+  if (evtState.page === 1 && !evtState.verdict && !evtState.agent) {
+    loadEvents();
+  }
+}, 30000);
 </script>
 </body>
 </html>

--- a/warden/server.py
+++ b/warden/server.py
@@ -1,0 +1,109 @@
+"""warden/server.py — local HTTP API server for the Prismor Warden dashboard.
+
+Serves a self-contained web dashboard and session/findings data from all
+registered workspace DBs.  No external dependencies beyond the stdlib and
+a single CDN link (Chart.js) loaded by the browser.
+
+Usage (via CLI):
+    python3 warden/cli.py serve [--port 7070] [--host 127.0.0.1]
+
+Endpoints:
+    GET /            → self-hosted HTML dashboard (Chart.js + polling)
+    GET /health      → {"status": "ok", "ts": "<iso>"}
+    GET /api/stats   → full aggregate stats JSON (all registered workspaces)
+    OPTIONS *        → 204 CORS preflight
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any, Dict
+
+from warden.store import get_aggregate_stats
+
+_DASHBOARD_HTML = Path(__file__).with_name("dashboard.html")
+
+_CORS_HEADERS = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+}
+
+
+class WardenRequestHandler(BaseHTTPRequestHandler):
+    """Minimal HTTP handler for the warden dashboard API."""
+
+    # Silence the default per-request access log
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        pass
+
+    def _send_cors(self) -> None:
+        for key, value in _CORS_HEADERS.items():
+            self.send_header(key, value)
+
+    def _send_json(self, data: Any, status: int = 200) -> None:
+        body = json.dumps(data, default=str).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self._send_cors()
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_html(self, html_path: Path) -> None:
+        try:
+            body = html_path.read_bytes()
+        except FileNotFoundError:
+            self._send_json({"error": "dashboard.html not found"}, status=500)
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self._send_cors()
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_OPTIONS(self) -> None:  # noqa: N802
+        self.send_response(204)
+        self._send_cors()
+        self.end_headers()
+
+    def do_GET(self) -> None:  # noqa: N802
+        path = self.path.split("?")[0].rstrip("/")
+
+        if path in ("", "/dashboard"):
+            self._send_html(_DASHBOARD_HTML)
+            return
+
+        if path == "/health":
+            self._send_json({"status": "ok", "ts": datetime.now(timezone.utc).isoformat()})
+            return
+
+        if path == "/api/stats":
+            try:
+                stats = get_aggregate_stats()
+            except Exception as exc:
+                self._send_json({"error": str(exc)}, status=500)
+                return
+            self._send_json(stats)
+            return
+
+        self._send_json({"error": "not found"}, status=404)
+
+    # Suppress BrokenPipeError tracebacks when clients disconnect early
+    def handle_error(self, request: Any, client_address: Any) -> None:
+        pass
+
+
+def run_server(host: str = "127.0.0.1", port: int = 7070) -> None:
+    """Start the warden HTTP API server (blocks until Ctrl-C)."""
+    server = HTTPServer((host, port), WardenRequestHandler)
+    print(f"[warden] dashboard → http://{host}:{port}  (Ctrl-C to stop)", flush=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\n[warden] server stopped", flush=True)
+    finally:
+        server.server_close()

--- a/warden/server.py
+++ b/warden/server.py
@@ -8,10 +8,13 @@ Usage (via CLI):
     python3 warden/cli.py serve [--port 7070] [--host 127.0.0.1]
 
 Endpoints:
-    GET /            → self-hosted HTML dashboard (Chart.js + polling)
-    GET /health      → {"status": "ok", "ts": "<iso>"}
-    GET /api/stats   → full aggregate stats JSON (all registered workspaces)
-    OPTIONS *        → 204 CORS preflight
+    GET /                  → self-hosted HTML dashboard
+    GET /health            → {"status": "ok", "ts": "<iso>"}
+    GET /api/stats         → aggregate stats for charts/KPIs
+    GET /api/sessions      → paginated sessions  (?page&limit&sort&dir)
+    GET /api/findings      → paginated findings  (?page&limit&agent&severity&category&q)
+    GET /api/events        → paginated events    (?page&limit&verdict&agent)
+    OPTIONS *              → 204 CORS preflight
 """
 from __future__ import annotations
 
@@ -20,8 +23,14 @@ from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any, Dict
+from urllib.parse import urlparse, parse_qs
 
-from warden.store import get_aggregate_stats
+from warden.store import (
+    get_aggregate_stats,
+    get_sessions_page,
+    get_findings_page,
+    get_events_page,
+)
 
 _DASHBOARD_HTML = Path(__file__).with_name("dashboard.html")
 
@@ -71,7 +80,18 @@ class WardenRequestHandler(BaseHTTPRequestHandler):
         self.end_headers()
 
     def do_GET(self) -> None:  # noqa: N802
-        path = self.path.split("?")[0].rstrip("/")
+        parsed = urlparse(self.path)
+        path = parsed.path.rstrip("/")
+        qs = parse_qs(parsed.query, keep_blank_values=False)
+
+        def qstr(key: str, default: str = "") -> str:
+            return qs.get(key, [default])[0]
+
+        def qint(key: str, default: int = 1) -> int:
+            try:
+                return int(qs.get(key, [default])[0])
+            except (ValueError, TypeError):
+                return default
 
         if path in ("", "/dashboard"):
             self._send_html(_DASHBOARD_HTML)
@@ -88,6 +108,50 @@ class WardenRequestHandler(BaseHTTPRequestHandler):
                 self._send_json({"error": str(exc)}, status=500)
                 return
             self._send_json(stats)
+            return
+
+        if path == "/api/sessions":
+            try:
+                data = get_sessions_page(
+                    page=qint("page", 1),
+                    limit=qint("limit", 20),
+                    sort=qstr("sort", "updatedAt"),
+                    direction=qstr("dir", "desc"),
+                )
+            except Exception as exc:
+                self._send_json({"error": str(exc)}, status=500)
+                return
+            self._send_json(data)
+            return
+
+        if path == "/api/findings":
+            try:
+                data = get_findings_page(
+                    page=qint("page", 1),
+                    limit=qint("limit", 25),
+                    agent=qstr("agent"),
+                    severity=qstr("severity"),
+                    category=qstr("category"),
+                    search=qstr("q"),
+                )
+            except Exception as exc:
+                self._send_json({"error": str(exc)}, status=500)
+                return
+            self._send_json(data)
+            return
+
+        if path == "/api/events":
+            try:
+                data = get_events_page(
+                    page=qint("page", 1),
+                    limit=qint("limit", 30),
+                    verdict=qstr("verdict"),
+                    agent=qstr("agent"),
+                )
+            except Exception as exc:
+                self._send_json({"error": str(exc)}, status=500)
+                return
+            self._send_json(data)
             return
 
         self._send_json({"error": "not found"}, status=404)

--- a/warden/store.py
+++ b/warden/store.py
@@ -360,3 +360,367 @@ def _truncate(value: str, max_length: int = 4000) -> str:
     if len(value) <= max_length:
         return value
     return f"{value[: max_length - 3]}..."
+
+
+# ── Dashboard aggregate stats ─────────────────────────────────────────────────
+
+_CATEGORY_MAP: Dict[str, str] = {
+    "prompt_injection":        "prompt_injection",
+    "jailbreak":               "jailbreak_attempt",
+    "remote_execution":        "tool_call_abuse",
+    "privilege_escalation":    "tool_call_abuse",
+    "db_modification":         "tool_call_abuse",
+    "rce_canary":              "tool_call_abuse",
+    "secret_exfiltration":     "secret_exfil",
+    "secret_access":           "secret_exfil",
+    "skill_risk":              "malicious_mcp",
+    "malicious_mcp":           "malicious_mcp",
+    "destructive_command":     "dangerous_command",
+    "dos_resource_exhaustion": "dangerous_command",
+    "persistence":             "dangerous_command",
+    "security_bypass":         "dangerous_command",
+    "dependency_risk":         "dangerous_command",
+}
+
+_DASH_CATEGORIES = [
+    "prompt_injection", "jailbreak_attempt", "tool_call_abuse",
+    "secret_exfil", "malicious_mcp", "dangerous_command",
+]
+
+_TYPE_LABEL: Dict[str, str] = {
+    "shell":        "bash",
+    "file_read":    "file_read",
+    "file_write":   "file_write",
+    "network":      "network",
+    "prompt":       "prompt",
+    "tool_result":  "tool_result",
+}
+
+
+def _relative_time_store(ts: str) -> str:
+    """Return a human-readable relative time string from an ISO timestamp."""
+    try:
+        from datetime import datetime, timezone
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        now = datetime.now(timezone.utc)
+        diff = int((now - dt).total_seconds())
+        if diff < 60:
+            return f"{diff}s ago"
+        if diff < 3600:
+            return f"{diff // 60}m ago"
+        if diff < 86400:
+            return f"{diff // 3600}h ago"
+        return f"{diff // 86400}d ago"
+    except Exception:
+        return ts
+
+
+def _connect_ro(db_path: Path):
+    """Open a SQLite DB read-only; returns None if unavailable."""
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+        return conn
+    except Exception:
+        return None
+
+
+def get_aggregate_stats(hours: int = 24) -> Dict[str, Any]:
+    """Query all registered workspace DBs and return dashboard-shaped data.
+
+    Returns empty/zero structures if no workspaces are registered or all DBs
+    are unavailable.
+    """
+    from collections import Counter
+    from datetime import datetime, timezone, timedelta
+
+    workspaces = list_registered_workspaces()
+
+    # Accumulators
+    active_sessions = 0
+    tool_calls_24h = 0
+    dangerous_prevented_24h = 0
+    tool_calls_prev = 0      # prior 24h window (for delta)
+    dangerous_prev = 0
+    active_prev = 0
+
+    threats_by_category: Counter = Counter()
+    agent_blocks: Counter = Counter()
+    tool_breakdown: Counter = Counter()
+
+    # keyed by date string → [total, flagged]
+    timeseries_acc: Dict[str, List[int]] = {}
+
+    patterns_acc: Dict[str, Dict[str, Any]] = {}  # key = title
+
+    live_events_raw: List[Dict[str, Any]] = []
+    top_users_acc: Dict[str, Dict[str, Any]] = {}
+    top_mcp_acc: Dict[str, Dict[str, Any]] = {}
+
+    for ws in workspaces:
+        db_path = get_db_path(ws)
+        conn = _connect_ro(db_path)
+        if conn is None:
+            continue
+        try:
+            # ── KPIs ──────────────────────────────────────────────────────
+            row = conn.execute(
+                "SELECT COUNT(*) FROM sessions WHERE updated_at >= datetime('now', ?)",
+                (f"-{hours} hours",),
+            ).fetchone()
+            active_sessions += (row[0] or 0)
+
+            row = conn.execute(
+                "SELECT COUNT(*) FROM sessions WHERE updated_at >= datetime('now', ?) "
+                "AND updated_at < datetime('now', ?)",
+                (f"-{hours * 2} hours", f"-{hours} hours"),
+            ).fetchone()
+            active_prev += (row[0] or 0)
+
+            row = conn.execute(
+                "SELECT COUNT(*) FROM events WHERE ts >= datetime('now', ?)",
+                (f"-{hours} hours",),
+            ).fetchone()
+            tool_calls_24h += (row[0] or 0)
+
+            row = conn.execute(
+                "SELECT COUNT(*) FROM events WHERE ts >= datetime('now', ?) "
+                "AND ts < datetime('now', ?)",
+                (f"-{hours * 2} hours", f"-{hours} hours"),
+            ).fetchone()
+            tool_calls_prev += (row[0] or 0)
+
+            row = conn.execute(
+                """
+                SELECT COUNT(*) FROM findings f
+                LEFT JOIN events e ON e.session_id = f.session_id
+                WHERE f.category IN ('destructive_command','dos_resource_exhaustion')
+                  AND e.ts >= datetime('now', ?)
+                """,
+                (f"-{hours} hours",),
+            ).fetchone()
+            dangerous_prevented_24h += (row[0] or 0)
+
+            row = conn.execute(
+                """
+                SELECT COUNT(*) FROM findings f
+                LEFT JOIN events e ON e.session_id = f.session_id
+                WHERE f.category IN ('destructive_command','dos_resource_exhaustion')
+                  AND e.ts >= datetime('now', ?)
+                  AND e.ts < datetime('now', ?)
+                """,
+                (f"-{hours * 2} hours", f"-{hours} hours"),
+            ).fetchone()
+            dangerous_prev += (row[0] or 0)
+
+            # ── Threats by category ───────────────────────────────────────
+            for row in conn.execute("SELECT category, COUNT(*) as cnt FROM findings GROUP BY category"):
+                dash_cat = _CATEGORY_MAP.get(row["category"] or "", "dangerous_command")
+                threats_by_category[dash_cat] += row["cnt"]
+
+            # ── Block rate timeseries (30 days) ───────────────────────────
+            for row in conn.execute(
+                """
+                SELECT date(e.ts) as day,
+                       COUNT(DISTINCT e.id) as total_events,
+                       COUNT(DISTINCT f.rowid) as flagged_events
+                FROM events e
+                LEFT JOIN findings f ON f.session_id = e.session_id
+                WHERE e.ts >= datetime('now', '-30 days')
+                GROUP BY day
+                """
+            ):
+                day = row["day"] or ""
+                if day not in timeseries_acc:
+                    timeseries_acc[day] = [0, 0]
+                timeseries_acc[day][0] += row["total_events"] or 0
+                timeseries_acc[day][1] += row["flagged_events"] or 0
+
+            # ── Agent blocked commands ────────────────────────────────────
+            for row in conn.execute(
+                """
+                SELECT s.agent, COUNT(f.finding_id) as blocked
+                FROM findings f JOIN sessions s ON s.session_id = f.session_id
+                GROUP BY s.agent
+                """
+            ):
+                agent = row["agent"] or "unknown"
+                agent_blocks[agent] += row["blocked"] or 0
+
+            # ── Tool call breakdown ───────────────────────────────────────
+            for row in conn.execute("SELECT type, COUNT(*) as count FROM events GROUP BY type"):
+                label = _TYPE_LABEL.get(row["type"] or "", row["type"] or "other")
+                tool_breakdown[label] += row["count"] or 0
+
+            # ── Top patterns ─────────────────────────────────────────────
+            for row in conn.execute(
+                """
+                SELECT f.title, f.category, f.severity,
+                       COUNT(*) as count, MAX(e.ts) as last_seen_ts
+                FROM findings f
+                LEFT JOIN events e ON e.session_id = f.session_id
+                GROUP BY f.title, f.category, f.severity
+                ORDER BY count DESC LIMIT 30
+                """
+            ):
+                title = row["title"] or "Unknown"
+                if title not in patterns_acc:
+                    patterns_acc[title] = {
+                        "pattern": title,
+                        "category": _CATEGORY_MAP.get(row["category"] or "", "dangerous_command"),
+                        "severity": (row["severity"] or "low").lower(),
+                        "count": 0,
+                        "lastSeen": "",
+                        "lastSeenTs": "",
+                    }
+                patterns_acc[title]["count"] += row["count"] or 0
+                ts = row["last_seen_ts"] or ""
+                if ts > patterns_acc[title]["lastSeenTs"]:
+                    patterns_acc[title]["lastSeenTs"] = ts
+                    patterns_acc[title]["lastSeen"] = _relative_time_store(ts) if ts else ""
+
+            # ── Live events ───────────────────────────────────────────────
+            for row in conn.execute(
+                """
+                SELECT e.ts, s.agent, e.type as action_type,
+                       e.command_text, e.path_text, e.url_text,
+                       f.severity,
+                       CASE WHEN f.finding_id IS NOT NULL THEN 'blocked' ELSE 'allowed' END as verdict
+                FROM events e
+                JOIN sessions s ON s.session_id = e.session_id
+                LEFT JOIN findings f ON f.session_id = e.session_id
+                WHERE e.ts >= datetime('now', '-24 hours')
+                ORDER BY e.ts DESC LIMIT 100
+                """
+            ):
+                action_parts = []
+                if row["action_type"]:
+                    action_parts.append(row["action_type"])
+                detail = row["command_text"] or row["path_text"] or row["url_text"] or ""
+                if detail:
+                    action_parts.append(detail[:60])
+                live_events_raw.append({
+                    "ts": (row["ts"] or "")[-8:] or "00:00:00",
+                    "agent": row["agent"] or "unknown",
+                    "action": ": ".join(action_parts) if action_parts else "event",
+                    "verdict": row["verdict"] or "allowed",
+                    "severity": (row["severity"] or "low").lower(),
+                })
+
+            # ── Top users by blocks ───────────────────────────────────────
+            for row in conn.execute(
+                """
+                SELECT substr(f.session_id, 1, 10) as userId,
+                       COUNT(f.finding_id) as blocked, MAX(e.ts) as last_seen_ts
+                FROM findings f
+                LEFT JOIN events e ON e.session_id = f.session_id
+                GROUP BY userId
+                ORDER BY blocked DESC LIMIT 10
+                """
+            ):
+                uid = row["userId"] or "unknown"
+                if uid not in top_users_acc:
+                    top_users_acc[uid] = {"userId": uid, "blocked": 0, "lastSeen": "", "lastSeenTs": ""}
+                top_users_acc[uid]["blocked"] += row["blocked"] or 0
+                ts = row["last_seen_ts"] or ""
+                if ts > top_users_acc[uid]["lastSeenTs"]:
+                    top_users_acc[uid]["lastSeenTs"] = ts
+                    top_users_acc[uid]["lastSeen"] = _relative_time_store(ts) if ts else ""
+
+            # ── Top MCP / skills ─────────────────────────────────────────
+            for row in conn.execute(
+                """
+                SELECT COALESCE(e.agent_event, e.type, 'unknown') as name,
+                       e.type,
+                       COUNT(*) as calls,
+                       COUNT(f.finding_id) as blocked
+                FROM events e
+                LEFT JOIN findings f ON f.session_id = e.session_id
+                GROUP BY name
+                ORDER BY calls DESC LIMIT 15
+                """
+            ):
+                name = row["name"] or "unknown"
+                if name not in top_mcp_acc:
+                    top_mcp_acc[name] = {
+                        "name": name,
+                        "type": "mcp" if "mcp" in name.lower() else "skill",
+                        "calls": 0,
+                        "blocked": 0,
+                    }
+                top_mcp_acc[name]["calls"] += row["calls"] or 0
+                top_mcp_acc[name]["blocked"] += row["blocked"] or 0
+
+        except Exception:
+            pass
+        finally:
+            conn.close()
+
+    # ── Deltas ────────────────────────────────────────────────────────────────
+    def _pct_delta(current: int, prior: int) -> float:
+        if prior == 0:
+            return 0.0
+        return round((current - prior) / prior * 100, 1)
+
+    # ── Block rate timeseries — fill 30-day window ────────────────────────────
+    today = datetime.now(timezone.utc).date()
+    timeseries: List[Dict[str, Any]] = []
+    for i in range(29, -1, -1):
+        day_date = today - timedelta(days=i)
+        day_str = day_date.isoformat()
+        total, flagged = timeseries_acc.get(day_str, [0, 0])
+        timeseries.append({
+            "date": day_str,
+            "intercepted": flagged,
+            "passed": max(0, total - flagged),
+        })
+
+    # ── Assemble threatsByCategory with all 6 keys always present ────────────
+    threats_out = {cat: threats_by_category.get(cat, 0) for cat in _DASH_CATEGORIES}
+
+    # ── Sort and trim ─────────────────────────────────────────────────────────
+    top_patterns = sorted(patterns_acc.values(), key=lambda x: x["count"], reverse=True)[:20]
+    for p in top_patterns:
+        p.pop("lastSeenTs", None)
+
+    top_users = sorted(top_users_acc.values(), key=lambda x: x["blocked"], reverse=True)[:10]
+    for u in top_users:
+        u.pop("lastSeenTs", None)
+
+    # Deduplicate live events (same ts+agent+action), keep 50
+    seen = set()
+    live_events_deduped = []
+    for ev in live_events_raw:
+        key = (ev["ts"], ev["agent"], ev["action"][:30])
+        if key not in seen:
+            seen.add(key)
+            live_events_deduped.append(ev)
+        if len(live_events_deduped) >= 50:
+            break
+
+    return {
+        "kpis": {
+            "activeSessions": active_sessions,
+            "toolCallsInspected24h": tool_calls_24h,
+            "dangerousCommandsPrevented24h": dangerous_prevented_24h,
+            "deltas": {
+                "threats": _pct_delta(sum(threats_out.values()), 0),
+                "tools": _pct_delta(tool_calls_24h, tool_calls_prev),
+                "dangerous": _pct_delta(dangerous_prevented_24h, dangerous_prev),
+            },
+        },
+        "threatsByCategory": threats_out,
+        "blockRateTimeseries": timeseries,
+        "agentBlockedCommands": [
+            {"agent": agent, "blocked": count}
+            for agent, count in agent_blocks.most_common(10)
+        ],
+        "toolCallBreakdown": [
+            {"tool": tool, "count": count}
+            for tool, count in tool_breakdown.most_common(10)
+        ],
+        "topPatterns": top_patterns,
+        "liveEvents": live_events_deduped,
+        "topUsersByBlocks": top_users,
+        "topMcpAndSkills": sorted(top_mcp_acc.values(), key=lambda x: x["calls"], reverse=True)[:15],
+    }

--- a/warden/store.py
+++ b/warden/store.py
@@ -457,8 +457,6 @@ def get_aggregate_stats(hours: int = 24) -> Dict[str, Any]:
     top_users_acc: Dict[str, Dict[str, Any]] = {}
     top_mcp_acc: Dict[str, Dict[str, Any]] = {}
     severity_breakdown: Counter = Counter()
-    recent_sessions_raw: List[Dict[str, Any]] = []
-    recent_findings_raw: List[Dict[str, Any]] = []
 
     for ws in workspaces:
         db_path = get_db_path(ws)
@@ -661,54 +659,6 @@ def get_aggregate_stats(hours: int = 24) -> Dict[str, Any]:
                 sev = (row["severity"] or "low").lower()
                 severity_breakdown[sev] += row["cnt"]
 
-            # ── Recent sessions ───────────────────────────────────────────
-            for row in conn.execute(
-                """
-                SELECT session_id, agent, risk_score, findings_count,
-                       started_at, updated_at, workspace_path
-                FROM sessions
-                ORDER BY updated_at DESC LIMIT 30
-                """
-            ):
-                recent_sessions_raw.append({
-                    "sessionId": (row["session_id"] or "")[:16],
-                    "agent": row["agent"] or "unknown",
-                    "riskScore": row["risk_score"] or 0,
-                    "findingsCount": row["findings_count"] or 0,
-                    "updatedAt": _relative_time_store(row["updated_at"]) if row["updated_at"] else "",
-                    "updatedAtTs": row["updated_at"] or "",
-                    "workspace": Path(row["workspace_path"] or "").name if row["workspace_path"] else "",
-                })
-
-            # ── Recent findings with evidence ─────────────────────────────
-            for row in conn.execute(
-                """
-                SELECT f.finding_id, f.session_id, f.title, f.category,
-                       f.severity, f.evidence, s.agent,
-                       MAX(e.ts) as ts,
-                       MAX(e.command_text) as command_text,
-                       MAX(e.path_text) as path_text,
-                       MAX(e.url_text) as url_text
-                FROM findings f
-                JOIN sessions s ON s.session_id = f.session_id
-                LEFT JOIN events e ON e.session_id = f.session_id
-                GROUP BY f.finding_id
-                ORDER BY ts DESC LIMIT 100
-                """
-            ):
-                recent_findings_raw.append({
-                    "id": (row["finding_id"] or "")[:16],
-                    "sessionId": (row["session_id"] or "")[:16],
-                    "title": row["title"] or "Unknown",
-                    "category": _CATEGORY_MAP.get(row["category"] or "", "dangerous_command"),
-                    "severity": (row["severity"] or "low").lower(),
-                    "evidence": (row["evidence"] or "")[:300],
-                    "agent": row["agent"] or "unknown",
-                    "ts": _relative_time_store(row["ts"]) if row["ts"] else "",
-                    "tsRaw": row["ts"] or "",
-                    "command": (row["command_text"] or row["path_text"] or row["url_text"] or "")[:120],
-                })
-
         except Exception:
             pass
         finally:
@@ -744,14 +694,6 @@ def get_aggregate_stats(hours: int = 24) -> Dict[str, Any]:
     top_users = sorted(top_users_acc.values(), key=lambda x: x["blocked"], reverse=True)[:10]
     for u in top_users:
         u.pop("lastSeenTs", None)
-
-    recent_sessions_out = sorted(recent_sessions_raw, key=lambda x: x["updatedAtTs"], reverse=True)[:20]
-    for s in recent_sessions_out:
-        s.pop("updatedAtTs", None)
-
-    recent_findings_out = sorted(recent_findings_raw, key=lambda x: x["tsRaw"], reverse=True)[:60]
-    for f in recent_findings_out:
-        f.pop("tsRaw", None)
 
     # Deduplicate live events (same ts+agent+action), keep 50
     seen = set()
@@ -795,6 +737,244 @@ def get_aggregate_stats(hours: int = 24) -> Dict[str, Any]:
             "medium": severity_breakdown.get("medium", 0),
             "low": severity_breakdown.get("low", 0),
         },
-        "recentSessions": recent_sessions_out,
-        "recentFindings": recent_findings_out,
+    }
+
+
+# ── Reverse category map (dashboard cat → list of raw DB cats) ────────────────
+_REVERSE_CATEGORY_MAP: Dict[str, List[str]] = {}
+for _raw_cat, _dash_cat in _CATEGORY_MAP.items():
+    _REVERSE_CATEGORY_MAP.setdefault(_dash_cat, []).append(_raw_cat)
+
+_VALID_SESSION_SORTS: Dict[str, str] = {
+    "sessionId": "session_id",
+    "agent": "agent",
+    "workspace": "workspace_path",
+    "riskScore": "risk_score",
+    "findingsCount": "findings_count",
+    "startedAt": "started_at",
+    "updatedAt": "updated_at",
+}
+
+
+def get_sessions_page(
+    page: int = 1,
+    limit: int = 20,
+    sort: str = "updatedAt",
+    direction: str = "desc",
+) -> Dict[str, Any]:
+    """Return a paginated list of sessions across all registered workspaces."""
+    sort_col = _VALID_SESSION_SORTS.get(sort, "updated_at")
+    reverse = direction.lower() != "asc"
+    workspaces = list_registered_workspaces()
+    rows: List[Dict[str, Any]] = []
+
+    for ws in workspaces:
+        db_path = get_db_path(ws)
+        conn = _connect_ro(db_path)
+        if conn is None:
+            continue
+        try:
+            for row in conn.execute(
+                "SELECT session_id, agent, risk_score, findings_count, "
+                "started_at, updated_at, workspace_path FROM sessions LIMIT 5000"
+            ):
+                rows.append({
+                    "sessionId": (row["session_id"] or "")[:20],
+                    "agent": row["agent"] or "unknown",
+                    "riskScore": row["risk_score"] or 0,
+                    "findingsCount": row["findings_count"] or 0,
+                    "startedAt": _relative_time_store(row["started_at"]) if row["started_at"] else "",
+                    "updatedAt": _relative_time_store(row["updated_at"]) if row["updated_at"] else "",
+                    "_sortRaw": row[sort_col] or "",
+                    "workspace": Path(row["workspace_path"] or "").name if row["workspace_path"] else "",
+                })
+        except Exception:
+            pass
+        finally:
+            conn.close()
+
+    rows.sort(key=lambda x: x["_sortRaw"] or "", reverse=reverse)
+    total = len(rows)
+    limit = max(1, min(limit, 200))
+    pages = max(1, (total + limit - 1) // limit)
+    page = max(1, min(page, pages))
+    offset = (page - 1) * limit
+    items = rows[offset: offset + limit]
+    for r in items:
+        r.pop("_sortRaw", None)
+
+    return {"items": items, "total": total, "page": page, "pages": pages, "limit": limit}
+
+
+def get_findings_page(
+    page: int = 1,
+    limit: int = 25,
+    agent: str = "",
+    severity: str = "",
+    category: str = "",
+    search: str = "",
+) -> Dict[str, Any]:
+    """Return a paginated, filtered list of findings across all registered workspaces."""
+    severity_filter = severity.lower() if severity else ""
+    raw_cats = _REVERSE_CATEGORY_MAP.get(category, []) if category else []
+    workspaces = list_registered_workspaces()
+    rows: List[Dict[str, Any]] = []
+
+    for ws in workspaces:
+        db_path = get_db_path(ws)
+        conn = _connect_ro(db_path)
+        if conn is None:
+            continue
+        try:
+            where_clauses: List[str] = []
+            params: List[Any] = []
+            if severity_filter:
+                where_clauses.append("LOWER(f.severity) = ?")
+                params.append(severity_filter)
+            if raw_cats:
+                placeholders = ",".join("?" * len(raw_cats))
+                where_clauses.append(f"f.category IN ({placeholders})")
+                params.extend(raw_cats)
+            if agent:
+                where_clauses.append("s.agent = ?")
+                params.append(agent)
+            if search:
+                where_clauses.append("(LOWER(f.title) LIKE ? OR LOWER(COALESCE(f.evidence,'')) LIKE ?)")
+                params.extend([f"%{search.lower()}%"] * 2)
+            where = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+            for row in conn.execute(
+                f"""
+                SELECT f.finding_id, f.session_id, f.title, f.category,
+                       f.severity, f.evidence, s.agent,
+                       MAX(e.ts) as ts,
+                       MAX(e.command_text) as command_text,
+                       MAX(e.path_text) as path_text,
+                       MAX(e.url_text) as url_text
+                FROM findings f
+                JOIN sessions s ON s.session_id = f.session_id
+                LEFT JOIN events e ON e.session_id = f.session_id
+                {where}
+                GROUP BY f.finding_id
+                ORDER BY ts DESC LIMIT 5000
+                """,
+                params,
+            ):
+                rows.append({
+                    "id": (row["finding_id"] or "")[:20],
+                    "sessionId": (row["session_id"] or "")[:20],
+                    "title": row["title"] or "Unknown",
+                    "category": _CATEGORY_MAP.get(row["category"] or "", "dangerous_command"),
+                    "severity": (row["severity"] or "low").lower(),
+                    "evidence": (row["evidence"] or "")[:500],
+                    "agent": row["agent"] or "unknown",
+                    "ts": _relative_time_store(row["ts"]) if row["ts"] else "",
+                    "_tsRaw": row["ts"] or "",
+                    "command": (row["command_text"] or row["path_text"] or row["url_text"] or "")[:160],
+                })
+        except Exception:
+            pass
+        finally:
+            conn.close()
+
+    rows.sort(key=lambda x: x["_tsRaw"] or "", reverse=True)
+    all_agents = sorted({r["agent"] for r in rows})
+    all_cats = sorted({r["category"] for r in rows})
+    total = len(rows)
+    limit = max(1, min(limit, 200))
+    pages = max(1, (total + limit - 1) // limit)
+    page = max(1, min(page, pages))
+    offset = (page - 1) * limit
+    items = rows[offset: offset + limit]
+    for r in items:
+        r.pop("_tsRaw", None)
+
+    return {
+        "items": items, "total": total, "page": page, "pages": pages, "limit": limit,
+        "agents": all_agents, "categories": all_cats,
+    }
+
+
+def get_events_page(
+    page: int = 1,
+    limit: int = 30,
+    verdict: str = "",
+    agent: str = "",
+) -> Dict[str, Any]:
+    """Return a paginated, filtered list of events across all registered workspaces."""
+    workspaces = list_registered_workspaces()
+    rows: List[Dict[str, Any]] = []
+
+    for ws in workspaces:
+        db_path = get_db_path(ws)
+        conn = _connect_ro(db_path)
+        if conn is None:
+            continue
+        try:
+            where_clauses: List[str] = []
+            params: List[Any] = []
+            if agent:
+                where_clauses.append("s.agent = ?")
+                params.append(agent)
+            if verdict == "blocked":
+                where_clauses.append("s.findings_count > 0")
+            elif verdict == "allowed":
+                where_clauses.append("s.findings_count = 0")
+            where = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+            for row in conn.execute(
+                f"""
+                SELECT e.ts, s.agent, e.type as action_type,
+                       e.command_text, e.path_text, e.url_text,
+                       f.severity,
+                       CASE WHEN s.findings_count > 0 THEN 'blocked' ELSE 'allowed' END as verdict
+                FROM events e
+                JOIN sessions s ON s.session_id = e.session_id
+                LEFT JOIN findings f ON f.session_id = e.session_id
+                {where}
+                GROUP BY e.id
+                ORDER BY e.ts DESC LIMIT 5000
+                """,
+                params,
+            ):
+                action_parts = []
+                if row["action_type"]:
+                    action_parts.append(row["action_type"])
+                detail = row["command_text"] or row["path_text"] or row["url_text"] or ""
+                if detail:
+                    action_parts.append(detail[:80])
+                rows.append({
+                    "ts": _relative_time_store(row["ts"]) if row["ts"] else "",
+                    "_tsRaw": row["ts"] or "",
+                    "agent": row["agent"] or "unknown",
+                    "action": ": ".join(action_parts) if action_parts else "event",
+                    "verdict": row["verdict"] or "allowed",
+                    "severity": (row["severity"] or "low").lower(),
+                })
+        except Exception:
+            pass
+        finally:
+            conn.close()
+
+    # Deduplicate then sort
+    seen: set = set()
+    deduped: List[Dict[str, Any]] = []
+    for ev in rows:
+        key = (ev["_tsRaw"], ev["agent"], ev["action"][:40])
+        if key not in seen:
+            seen.add(key)
+            deduped.append(ev)
+    deduped.sort(key=lambda x: x["_tsRaw"] or "", reverse=True)
+
+    all_agents = sorted({ev["agent"] for ev in deduped})
+    total = len(deduped)
+    limit = max(1, min(limit, 200))
+    pages = max(1, (total + limit - 1) // limit)
+    page = max(1, min(page, pages))
+    offset = (page - 1) * limit
+    items = deduped[offset: offset + limit]
+    for r in items:
+        r.pop("_tsRaw", None)
+
+    return {
+        "items": items, "total": total, "page": page, "pages": pages, "limit": limit,
+        "agents": all_agents,
     }

--- a/warden/store.py
+++ b/warden/store.py
@@ -456,6 +456,9 @@ def get_aggregate_stats(hours: int = 24) -> Dict[str, Any]:
     live_events_raw: List[Dict[str, Any]] = []
     top_users_acc: Dict[str, Dict[str, Any]] = {}
     top_mcp_acc: Dict[str, Dict[str, Any]] = {}
+    severity_breakdown: Counter = Counter()
+    recent_sessions_raw: List[Dict[str, Any]] = []
+    recent_findings_raw: List[Dict[str, Any]] = []
 
     for ws in workspaces:
         db_path = get_db_path(ws)
@@ -651,6 +654,61 @@ def get_aggregate_stats(hours: int = 24) -> Dict[str, Any]:
                 top_mcp_acc[name]["calls"] += row["calls"] or 0
                 top_mcp_acc[name]["blocked"] += row["blocked"] or 0
 
+            # ── Severity breakdown ────────────────────────────────────────
+            for row in conn.execute(
+                "SELECT severity, COUNT(*) as cnt FROM findings GROUP BY severity"
+            ):
+                sev = (row["severity"] or "low").lower()
+                severity_breakdown[sev] += row["cnt"]
+
+            # ── Recent sessions ───────────────────────────────────────────
+            for row in conn.execute(
+                """
+                SELECT session_id, agent, risk_score, findings_count,
+                       started_at, updated_at, workspace_path
+                FROM sessions
+                ORDER BY updated_at DESC LIMIT 30
+                """
+            ):
+                recent_sessions_raw.append({
+                    "sessionId": (row["session_id"] or "")[:16],
+                    "agent": row["agent"] or "unknown",
+                    "riskScore": row["risk_score"] or 0,
+                    "findingsCount": row["findings_count"] or 0,
+                    "updatedAt": _relative_time_store(row["updated_at"]) if row["updated_at"] else "",
+                    "updatedAtTs": row["updated_at"] or "",
+                    "workspace": Path(row["workspace_path"] or "").name if row["workspace_path"] else "",
+                })
+
+            # ── Recent findings with evidence ─────────────────────────────
+            for row in conn.execute(
+                """
+                SELECT f.finding_id, f.session_id, f.title, f.category,
+                       f.severity, f.evidence, s.agent,
+                       MAX(e.ts) as ts,
+                       MAX(e.command_text) as command_text,
+                       MAX(e.path_text) as path_text,
+                       MAX(e.url_text) as url_text
+                FROM findings f
+                JOIN sessions s ON s.session_id = f.session_id
+                LEFT JOIN events e ON e.session_id = f.session_id
+                GROUP BY f.finding_id
+                ORDER BY ts DESC LIMIT 100
+                """
+            ):
+                recent_findings_raw.append({
+                    "id": (row["finding_id"] or "")[:16],
+                    "sessionId": (row["session_id"] or "")[:16],
+                    "title": row["title"] or "Unknown",
+                    "category": _CATEGORY_MAP.get(row["category"] or "", "dangerous_command"),
+                    "severity": (row["severity"] or "low").lower(),
+                    "evidence": (row["evidence"] or "")[:300],
+                    "agent": row["agent"] or "unknown",
+                    "ts": _relative_time_store(row["ts"]) if row["ts"] else "",
+                    "tsRaw": row["ts"] or "",
+                    "command": (row["command_text"] or row["path_text"] or row["url_text"] or "")[:120],
+                })
+
         except Exception:
             pass
         finally:
@@ -686,6 +744,14 @@ def get_aggregate_stats(hours: int = 24) -> Dict[str, Any]:
     top_users = sorted(top_users_acc.values(), key=lambda x: x["blocked"], reverse=True)[:10]
     for u in top_users:
         u.pop("lastSeenTs", None)
+
+    recent_sessions_out = sorted(recent_sessions_raw, key=lambda x: x["updatedAtTs"], reverse=True)[:20]
+    for s in recent_sessions_out:
+        s.pop("updatedAtTs", None)
+
+    recent_findings_out = sorted(recent_findings_raw, key=lambda x: x["tsRaw"], reverse=True)[:60]
+    for f in recent_findings_out:
+        f.pop("tsRaw", None)
 
     # Deduplicate live events (same ts+agent+action), keep 50
     seen = set()
@@ -723,4 +789,12 @@ def get_aggregate_stats(hours: int = 24) -> Dict[str, Any]:
         "liveEvents": live_events_deduped,
         "topUsersByBlocks": top_users,
         "topMcpAndSkills": sorted(top_mcp_acc.values(), key=lambda x: x["calls"], reverse=True)[:15],
+        "severityBreakdown": {
+            "critical": severity_breakdown.get("critical", 0),
+            "high": severity_breakdown.get("high", 0),
+            "medium": severity_breakdown.get("medium", 0),
+            "low": severity_breakdown.get("low", 0),
+        },
+        "recentSessions": recent_sessions_out,
+        "recentFindings": recent_findings_out,
     }


### PR DESCRIPTION
## Summary
- Adds `warden serve` CLI command that starts a local HTTP API server (default `127.0.0.1:7070`)
- New `warden/server.py`: stdlib-only HTTP server serving session/findings data from all registered workspace DBs
- New `warden/dashboard.html`: self-contained web dashboard using Chart.js for live polling and visualization
- Updates `warden/store.py` with data aggregation support and `README.md` with usage docs

## Test plan
- [ ] Run `warden install-hooks` in a project, then `warden serve` — dashboard should load at `http://127.0.0.1:7070`
- [ ] Verify `/api/stats` returns aggregate data from registered workspaces
- [ ] Verify `/health` endpoint returns `{"status": "ok"}`
- [ ] Test with no registered workspaces — warning should appear in stderr, server still starts
- [ ] Confirm no external Python dependencies are introduced (stdlib only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)