### PR TITLE
Prompt injection defense added

### DIFF
--- a/warden/default_policy.yaml
+++ b/warden/default_policy.yaml
@@ -167,6 +167,27 @@ rules:
       - '(ignore\s+(all\s+)?(any\s+)?(previous\s+)?instructions|reveal (your|the) system prompt|developer instructions|exfiltrat(e|ion)|print .*secret|show .*token|bypass guardrails|jailbreak)'
     action: block
 
+  # ── CRITICAL: Prompt injection hidden in HTML/CSS/invisible chars ─────
+  # Catches payloads that survive the naive regex above because they are
+  # wrapped in HTML comments, rendered invisible via CSS, or placed inside
+  # aria-hidden elements. Zero-width-char obfuscation is caught by the
+  # sanitizer module (warden/sanitizer.py) which runs on the raw response
+  # outside the YAML rule engine.
+  - id: prompt-injection-hidden
+    severity: CRITICAL
+    category: prompt_injection
+    title: Detects prompt injection hidden in HTML comments, CSS-invisible elements, or aria-hidden elements
+    event_types: [tool_result]
+    fields: [combined_text]
+    patterns:
+      # Injection keyword inside an HTML comment: <!-- ... ignore previous instructions ... -->
+      - '<!--.*?(?:ignore\s+(?:all\s+)?(?:any\s+)?(?:previous\s+)?instructions|disregard\s+(?:all\s+)?(?:previous\s+)?(?:instructions|rules)|forget\s+(?:everything|all\s+previous|your\s+instructions)|new\s+(?:primary\s+)?instruction|reveal\s+(?:your\s+)?(?:system\s+prompt|api\s+key|secret|token)|exfiltrat|fetch\s+https?://).*?-->'
+      # Injection text following a CSS-hidden style attribute (avoids quote-char class issues)
+      - 'style=[^>]*(?:display\s*:\s*none|visibility\s*:\s*hidden|font-size\s*:\s*0)[^>]*>[^<]{0,400}(?:ignore\s+(?:all\s+)?(?:previous\s+)?instructions|exfiltrat|fetch\s+https?://)'
+      # Injection text inside an aria-hidden element (.true. matches "true" or ''true'')
+      - 'aria-hidden\s*=\s*.true.[^>]*>[^<]{0,300}(?:ignore\s+(?:all\s+)?(?:any\s+)?(?:previous\s+)?instructions|disregard|new\s+instruction|exfiltrat|fetch\s+https?://)'
+    action: block
+
   # ── HIGH: Remote fetch-and-execute ────────────────────────────────────
   - id: remote-execution
     severity: HIGH
@@ -199,6 +220,35 @@ rules:
     fields: [url]
     patterns:
       - '(webhook\.site|ngrok-free\.app|ngrok\.io|pastebin\.com|discord(app)?\.com/api/webhooks|transfer\.sh)'
+    action: block
+
+  # ── CRITICAL: API key or token in outbound URL parameters ─────────────
+  # Catches the response-blind exfiltration pattern where a prompt-injected
+  # agent sends a secret as a URL query parameter. The attacker only needs
+  # the outbound request to hit their server — they never read a response.
+  # Patterns match well-known API key shapes; the policy engine also checks
+  # enrolled cloaking secrets dynamically (any shape, no pattern needed).
+  - id: secret-in-url-params
+    severity: CRITICAL
+    category: secret_exfiltration
+    title: API key or token detected in outbound URL parameters
+    event_types: [network]
+    fields: [url]
+    patterns:
+      # Anthropic / OpenAI style keys (sk-... prefix, 30+ chars)
+      - '[?&][^=&\s]+=sk-(?:ant-api03-|proj-)?[a-zA-Z0-9_-]{30,}'
+      # Generic sk- keys (e.g. older OpenAI format)
+      - '[?&][^=&\s]+=sk-[a-zA-Z0-9]{32,}'
+      # GitHub personal access tokens (classic and fine-grained)
+      - '[?&][^=&\s]+=(?:ghp|gho|ghs|ghr|github_pat)_[a-zA-Z0-9_]{20,}'
+      # AWS access key ID
+      - '[?&][^=&\s]+=AKIA[A-Z0-9]{16}'
+      # Slack tokens
+      - '[?&][^=&\s]+=xox[bpas]-[0-9]+-[a-zA-Z0-9-]+'
+      # Google API keys
+      - '[?&][^=&\s]+=AIza[0-9A-Za-z_-]{35}'
+      # Stripe live/test keys
+      - '[?&][^=&\s]+=sk_(?:live|test)_[a-zA-Z0-9]{24,}'
     action: block
 
   # ── HIGH: Database modification ───────────────────────────────────────

--- a/warden/policy_engine.py
+++ b/warden/policy_engine.py
@@ -6,6 +6,7 @@ evaluates events. Replaces the hardcoded patterns in policies.py.
 """
 from __future__ import annotations
 
+import json
 import re
 import sys
 from pathlib import Path
@@ -53,6 +54,90 @@ _DEFAULT_FIELDS: Dict[str, List[str]] = {
     "tool_result": ["combined_text"],
     "skill_manifest": ["combined_text"],
 }
+
+
+class _TaintStore:
+    """Per-session taint state persisted across hook invocations.
+
+    Tracks whether a prompt injection was detected in the current session
+    so that subsequent network calls can be escalated to CRITICAL regardless
+    of their destination.  Stored as a JSON file under
+    ``{workspace}/.prismor-warden/taint/{session_id}.json``.
+    """
+
+    def __init__(self, workspace: Path, session_id: str) -> None:
+        safe = "".join(
+            c if c.isalnum() or c in "._-" else "_" for c in session_id
+        )
+        self._path = workspace / ".prismor-warden" / "taint" / f"{safe}.json"
+        self.injection_detected: bool = False
+        self.injection_event_index: Optional[int] = None
+        self.seen_domains: set = set()
+        self._load()
+
+    def _load(self) -> None:
+        if not self._path.exists():
+            return
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+            self.injection_detected = bool(data.get("injection_detected", False))
+            self.injection_event_index = data.get("injection_event_index")
+            self.seen_domains = set(data.get("seen_domains", []))
+        except Exception:
+            pass
+
+    def _save(self) -> None:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._path.write_text(
+                json.dumps({
+                    "injection_detected": self.injection_detected,
+                    "injection_event_index": self.injection_event_index,
+                    "seen_domains": sorted(self.seen_domains),
+                }, indent=2),
+                encoding="utf-8",
+            )
+        except Exception:
+            pass
+
+    def mark_injection(self, event_index: int) -> None:
+        self.injection_detected = True
+        self.injection_event_index = event_index
+        self._save()
+
+    def add_domain(self, domain: str) -> None:
+        self.seen_domains.add(domain.lower())
+        self._save()
+
+    def is_new_domain(self, domain: str) -> bool:
+        return domain.lower() not in self.seen_domains
+
+
+def _check_cloaked_secrets_in_url(url: str) -> Optional[str]:
+    """Check whether any enrolled cloaking secret appears verbatim in the URL.
+
+    Returns the secret *name* (never the value) if a match is found,
+    or ``None`` if nothing matches or the secrets store is unavailable.
+    Secrets shorter than 8 characters are skipped to avoid false positives
+    on common short strings.
+    """
+    try:
+        from warden.cloaking.secrets_store import secrets_dir
+        sdir = secrets_dir()
+        if not sdir.exists():
+            return None
+        for secret_file in sorted(sdir.iterdir()):
+            if not secret_file.is_file():
+                continue
+            try:
+                value = secret_file.read_text(encoding="utf-8").strip()
+                if value and len(value) >= 8 and value in url:
+                    return secret_file.name
+            except Exception:
+                continue
+    except Exception:
+        pass
+    return None
 
 
 class CompiledRule:
@@ -109,6 +194,7 @@ class PolicyEngine:
         workspace: Optional[Path] = None,
         policy_path: Optional[Path] = None,
     ) -> None:
+        self.workspace: Optional[Path] = workspace
         self.rules: List[CompiledRule] = []
         self.allowlists: List[AllowlistEntry] = []
         self.block_categories: set[str] = set()
@@ -362,6 +448,98 @@ class PolicyEngine:
                     })
                     break  # One finding per command is enough.
 
+        # ── Prompt injection: structural HTML analysis (sanitizer) ─────────
+        # The YAML rules match injection keywords in plaintext. This pass
+        # catches payloads that survive because they are wrapped in HTML
+        # comments, hidden via CSS, or fragmented by zero-width characters.
+        # We call the sanitizer on the raw response field (not combined_text)
+        # so the HTML structure is intact.
+        if event_type == "tool_result":
+            raw_response = str(event.get("response", ""))
+            if raw_response:
+                try:
+                    from warden.sanitizer import detect_injections as _detect_html
+                    _html_detections = _detect_html(raw_response)
+                    for _det in _html_detections:
+                        finding_id = f"html-injection-{index}"
+                        prefixed_id = f"{session_id}:{finding_id}" if session_id else finding_id
+                        findings.append({
+                            "id": prefixed_id,
+                            "severity": "CRITICAL",
+                            "category": "prompt_injection",
+                            "title": "Prompt injection hidden in HTML structure of fetched page",
+                            "evidence": _truncate(_det),
+                            "eventIndex": index,
+                            "ruleId": "html-injection",
+                            "action": "block",
+                        })
+                except Exception:
+                    pass
+
+        # ── Taint tracking: mark session if injection detected ─────────────
+        # If this event produced any prompt_injection findings, persist that
+        # fact so subsequent network events can be escalated regardless of
+        # their destination.
+        taint = self._get_taint(session_id)
+        if taint is not None and any(
+            f.get("category") == "prompt_injection" for f in findings
+        ):
+            taint.mark_injection(index)
+
+        # ── Network event: cloaking-secret check + taint escalation ───────
+        if event_type == "network":
+            url = field_values.get("url", "")
+            if url:
+                # Check if any enrolled cloaking secret appears in the URL.
+                # This catches exfiltration of any shape of key, not just the
+                # well-known patterns in the YAML rule above.
+                _secret_name = _check_cloaked_secrets_in_url(url)
+                if _secret_name:
+                    finding_id = f"cloaked-secret-in-url-{index}"
+                    prefixed_id = f"{session_id}:{finding_id}" if session_id else finding_id
+                    findings.append({
+                        "id": prefixed_id,
+                        "severity": "CRITICAL",
+                        "category": "secret_exfiltration",
+                        "title": (
+                            f"Enrolled secret '@@SECRET:{_secret_name}@@' "
+                            f"detected in outbound URL"
+                        ),
+                        "evidence": "[secret value redacted from evidence]",
+                        "eventIndex": index,
+                        "ruleId": "cloaked-secret-in-url",
+                        "action": "block",
+                    })
+
+                # If this session previously had a prompt injection finding,
+                # any subsequent outbound network call is suspicious — escalate
+                # to CRITICAL regardless of destination.
+                if taint is None:
+                    taint = self._get_taint(session_id)
+                if taint is not None and taint.injection_detected:
+                    finding_id = f"taint-escalation-{index}"
+                    prefixed_id = f"{session_id}:{finding_id}" if session_id else finding_id
+                    findings.append({
+                        "id": prefixed_id,
+                        "severity": "CRITICAL",
+                        "category": "secret_exfiltration",
+                        "title": (
+                            "Outbound network call after prompt injection detected "
+                            "— possible response-blind exfiltration"
+                        ),
+                        "evidence": _truncate(url),
+                        "eventIndex": index,
+                        "ruleId": "taint-escalation",
+                        "action": "block",
+                    })
+
+                # Track seen domains so the taint store has context on what
+                # domains this session has legitimately contacted.
+                if taint is not None:
+                    _domain = _extract_domain(url)
+                    if _domain:
+                        taint.add_domain(_domain)
+
         return findings
 
     def check_command(self, command: str) -> List[Dict[str, Any]]:
@@ -398,6 +576,15 @@ class PolicyEngine:
                 if domain_lower == pattern_lower:
                     return True
         return False
+
+    def _get_taint(self, session_id: str) -> Optional[_TaintStore]:
+        """Return the taint store for this session, or None if unavailable."""
+        if not session_id or self.workspace is None:
+            return None
+        try:
+            return _TaintStore(self.workspace, session_id)
+        except Exception:
+            return None
 
 
 # ── Shared helpers ──────────────────────────────────────────────────────────

--- a/warden/sanitizer.py
+++ b/warden/sanitizer.py
@@ -1,0 +1,128 @@
+"""HTML content sanitizer — detects and strips injection vectors from fetched page content."""
+from __future__ import annotations
+
+import re
+from typing import List, Tuple
+
+
+# HTML comment blocks
+_HTML_COMMENT_RE = re.compile(r'<!--.*?-->', re.DOTALL)
+
+# Opening tag of any element with a style attribute containing a hiding property.
+# We match the opening tag only; content is inspected in a forward window.
+_HIDDEN_STYLE_OPEN_RE = re.compile(
+    r'<[a-zA-Z][a-zA-Z0-9]*[^>]+style\s*=\s*["\'][^"\']*(?:'
+    r'display\s*:\s*none'
+    r'|visibility\s*:\s*hidden'
+    r'|font-size\s*:\s*0(?:px)?'
+    r'|color\s*:\s*(?:white|#fff{1,3}|transparent|rgba\s*\([^)]*,\s*0(?:\.0*)?\s*\))'
+    r')[^"\']*["\'][^>]*>',
+    re.IGNORECASE | re.DOTALL,
+)
+
+# Opening tag of any element with aria-hidden="true"
+_ARIA_HIDDEN_OPEN_RE = re.compile(
+    r'<([a-zA-Z][a-zA-Z0-9]*)[^>]*aria-hidden\s*=\s*["\']true["\'][^>]*>',
+    re.IGNORECASE,
+)
+
+# Zero-width and invisible Unicode characters commonly used to break up keywords
+_INVISIBLE_RE = re.compile(r'[​‌‍⁠﻿]+')
+
+# Semantic injection signals — phrases that constitute a prompt injection attempt
+_INJECTION_SIGNALS_RE = re.compile(
+    r'ignore\s+(all\s+)?(any\s+)?(previous\s+)?instructions'
+    r'|disregard\s+(?:all\s+)?(?:previous\s+)?(?:instructions|rules)'
+    r'|forget\s+(?:everything|all\s+previous|your\s+instructions)'
+    r'|new\s+(?:primary\s+)?instruction'
+    r'|(?:reveal|print|show|output)\s+(?:your\s+)?(?:system\s+prompt|api\s+key|secret|token)'
+    r'|you\s+are\s+now\s+(?:a\s+)?(?:different|new)'
+    r'|act\s+as\s+if\s+(?:you|your)'
+    r'|exfiltrat(?:e|ion)'
+    r'|fetch\s+https?://'
+    r'|send\s+(?:a\s+)?(?:get|post|http)\s+request',
+    re.IGNORECASE,
+)
+
+# Window size (chars) to scan ahead of a hidden-element opening tag for payload text
+_LOOKAHEAD = 600
+
+
+def detect_injections(content: str) -> List[str]:
+    """Scan fetched page content for structurally hidden injection patterns.
+
+    Returns a list of human-readable detection descriptions.
+    An empty list means no structural injections were found.
+
+    This is a complement to regex-on-plaintext detection — it catches
+    payloads hidden via HTML comments, CSS visibility tricks, aria-hidden
+    attributes, and zero-width character obfuscation that survive into the
+    rendered text visible to the model.
+    """
+    detections: List[str] = []
+
+    # ── HTML comment injection ──────────────────────────────────────────
+    for m in _HTML_COMMENT_RE.finditer(content):
+        comment_text = m.group(0)
+        if _INJECTION_SIGNALS_RE.search(comment_text):
+            snip = comment_text[:140].replace('\n', ' ')
+            detections.append(f"injection payload inside HTML comment: {snip!r}")
+
+    # ── CSS-hidden element injection ────────────────────────────────────
+    for m in _HIDDEN_STYLE_OPEN_RE.finditer(content):
+        window = content[m.end():m.end() + _LOOKAHEAD]
+        if _INJECTION_SIGNALS_RE.search(window):
+            tag_snip = m.group(0)[:80].replace('\n', ' ')
+            pay_snip = window[:100].replace('\n', ' ')
+            detections.append(
+                f"injection payload in CSS-hidden element ({tag_snip!r}): {pay_snip!r}"
+            )
+
+    # ── aria-hidden element injection ───────────────────────────────────
+    for m in _ARIA_HIDDEN_OPEN_RE.finditer(content):
+        window = content[m.end():m.end() + _LOOKAHEAD]
+        if _INJECTION_SIGNALS_RE.search(window):
+            pay_snip = window[:120].replace('\n', ' ')
+            detections.append(
+                f"injection payload in aria-hidden element: {pay_snip!r}"
+            )
+
+    # ── Zero-width character obfuscation ───────────────────────────────
+    stripped = _INVISIBLE_RE.sub('', content)
+    if stripped != content:
+        for sig_m in _INJECTION_SIGNALS_RE.finditer(stripped):
+            detections.append(
+                f"injection keyword obscured by zero-width characters: "
+                f"{sig_m.group(0)[:80]!r}"
+            )
+            break  # one report per page is enough
+
+    return detections
+
+
+def sanitize(content: str) -> Tuple[str, List[str]]:
+    """Strip the most common injection vectors from HTML content.
+
+    Performs a best-effort in-place scrub. Returns the cleaned content
+    and a list of change descriptions. Does not require an HTML parser —
+    operates purely on the raw string, so it is safe to call on partial
+    or malformed HTML.
+    """
+    changes: List[str] = []
+
+    # Remove invisible/zero-width characters
+    cleaned = _INVISIBLE_RE.sub('', content)
+    if cleaned != content:
+        changes.append("stripped zero-width/invisible Unicode characters")
+    content = cleaned
+
+    # Replace HTML comments that contain injection signals with a safe placeholder
+    def _scrub_comment(m: re.Match) -> str:
+        if _INJECTION_SIGNALS_RE.search(m.group(0)):
+            changes.append("redacted HTML comment containing injection payload")
+            return '<!-- [redacted by Warden] -->'
+        return m.group(0)
+
+    content = _HTML_COMMENT_RE.sub(_scrub_comment, content)
+
+    return content, changes


### PR DESCRIPTION
   Add prompt injection defenses: HTML sanitizer, taint tracking, secret-in-URL detection                                                                          

   - warden/sanitizer.py (new): structural HTML injection detector and sanitizer;
     catches payloads hidden in HTML comments, CSS-invisible elements (display:none,
     visibility:hidden), aria-hidden elements, and zero-width character obfuscation

   - default_policy.yaml: two new CRITICAL rules —
     prompt-injection-hidden: matches injection in HTML comments, CSS-hidden elements,
     and aria-hidden elements in tool_result events
     secret-in-url-params: blocks outbound URLs carrying API key shapes (Anthropic,
     OpenAI, GitHub, AWS, Slack, Google, Stripe) in query parameters

   - policy_engine.py:
     _TaintStore: per-session taint state persisted across hook invocations; marks
     when a prompt injection is detected so subsequent network calls can be escalated
     _check_cloaked_secrets_in_url: checks enrolled cloaking secrets against outbound
     URLs regardless of key shape, returns secret name (never value)
     evaluate(): calls sanitizer on raw WebFetch responses, writes taint on injection
     findings, escalates any network call to CRITICAL if session is tainted, checks
     cloaking secrets on every outbound network event