### PR TITLE
fix(store): prevent JSONL corruption from concurrent session-log writes

### DIFF
--- a/tests/test_store_concurrent.py
+++ b/tests/test_store_concurrent.py
@@ -1,0 +1,111 @@
+"""Regression tests for warden.store session-log concurrency and reader robustness."""
+
+import json
+import os
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from warden.store import append_session_event, read_session_events, session_log_path
+
+
+class TestSessionLogConcurrency(unittest.TestCase):
+    """Concurrent appends from multiple threads must not interleave on a single line.
+
+    Before the fix, large events (>PIPE_BUF, ~4 KiB on Linux) could be spliced
+    by the kernel when two writers ran in parallel, producing JSONL lines that
+    contained two concatenated objects. The reader's old splitlines + json.loads
+    path then crashed with ``Extra data: line 1 column N``.
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmpdir.name)
+        self.session_id = "concurrent-session"
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_parallel_large_appends_round_trip(self):
+        n_threads = 8
+        events_per_thread = 50
+        # Payload size deliberately >PIPE_BUF (4096 on Linux) to exercise
+        # the non-atomic write path.
+        payload_filler = "x" * 8192
+
+        def writer(thread_idx: int):
+            for i in range(events_per_thread):
+                event = {
+                    "thread": thread_idx,
+                    "seq": i,
+                    "filler": payload_filler,
+                }
+                append_session_event(self.workspace, self.session_id, event)
+
+        threads = [
+            threading.Thread(target=writer, args=(t,)) for t in range(n_threads)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        events = read_session_events(self.workspace, self.session_id)
+        self.assertEqual(len(events), n_threads * events_per_thread)
+
+        seen = {(e["thread"], e["seq"]) for e in events}
+        self.assertEqual(len(seen), n_threads * events_per_thread)
+
+        log_path = session_log_path(self.workspace, self.session_id)
+        with log_path.open("r", encoding="utf-8") as fh:
+            for line_no, raw in enumerate(fh, start=1):
+                text = raw.strip()
+                if not text:
+                    continue
+                try:
+                    json.loads(text)
+                except json.JSONDecodeError as exc:
+                    self.fail(
+                        f"Line {line_no} is not a single JSON object after "
+                        f"concurrent writes ({exc}); size={len(raw)}"
+                    )
+
+
+class TestSessionLogReaderRobustness(unittest.TestCase):
+    """The reader must tolerate pre-existing concatenated-object corruption."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmpdir.name)
+        self.session_id = "legacy-corrupt"
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_reader_recovers_concatenated_objects_on_one_line(self):
+        log_path = session_log_path(self.workspace, self.session_id)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        a = json.dumps({"id": 1, "kind": "first"})
+        b = json.dumps({"id": 2, "kind": "second"})
+        c = json.dumps({"id": 3, "kind": "third"})
+        log_path.write_text(a + b + "\n" + c + "\n", encoding="utf-8")
+
+        events = read_session_events(self.workspace, self.session_id)
+        self.assertEqual([e["id"] for e in events], [1, 2, 3])
+
+    def test_reader_skips_trailing_garbage(self):
+        log_path = session_log_path(self.workspace, self.session_id)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        good = json.dumps({"id": 1})
+        log_path.write_text(good + "\n" + "{not json", encoding="utf-8")
+
+        events = read_session_events(self.workspace, self.session_id)
+        self.assertEqual(events, [{"id": 1}])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/warden/store.py
+++ b/warden/store.py
@@ -5,6 +5,17 @@ import sqlite3
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+try:
+    import fcntl  # POSIX advisory locks
+    _HAS_FCNTL = True
+except ImportError:
+    _HAS_FCNTL = False
+    try:
+        import msvcrt  # Windows file locking
+        _HAS_MSVCRT = True
+    except ImportError:
+        _HAS_MSVCRT = False
+
 
 # ── Global workspace registry ────────────────────────────────────────────────
 
@@ -82,16 +93,55 @@ def session_log_path(workspace: Path, session_id: str) -> Path:
 def append_session_event(workspace: Path, session_id: str, event: Dict[str, Any]) -> Path:
     ensure_data_dirs(workspace)
     log_path = session_log_path(workspace, session_id)
+    line = json.dumps(event) + "\n"
     with log_path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(event))
-        handle.write("\n")
+        if _HAS_FCNTL:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            try:
+                handle.write(line)
+                handle.flush()
+            finally:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        elif _HAS_MSVCRT:
+            try:
+                msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+            except OSError:
+                pass
+            try:
+                handle.write(line)
+                handle.flush()
+            finally:
+                try:
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                except OSError:
+                    pass
+        else:
+            handle.write(line)
+            handle.flush()
     return log_path
 
 
 def read_session_events(workspace: Path, session_id: str) -> List[Dict[str, Any]]:
     log_path = session_log_path(workspace, session_id)
+    events: List[Dict[str, Any]] = []
+    decoder = json.JSONDecoder()
     with log_path.open("r", encoding="utf-8") as handle:
-        return [json.loads(line) for line in handle.read().splitlines() if line.strip()]
+        for raw_line in handle:
+            text = raw_line.strip()
+            if not text:
+                continue
+            idx = 0
+            length = len(text)
+            while idx < length:
+                try:
+                    obj, end = decoder.raw_decode(text, idx)
+                except json.JSONDecodeError:
+                    break
+                events.append(obj)
+                idx = end
+                while idx < length and text[idx].isspace():
+                    idx += 1
+    return events
 
 
 def initialize_database(workspace: Path) -> Path:

--- a/warden/store.py
+++ b/warden/store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -15,6 +16,14 @@ except ImportError:
         _HAS_MSVCRT = True
     except ImportError:
         _HAS_MSVCRT = False
+
+# Region size for Windows msvcrt.locking. Must be larger than any single event
+# payload to provide effective mutual exclusion, since msvcrt locks are
+# byte-range based. 1 GiB comfortably covers Warden's bounded event payloads.
+_WIN_LOCK_BYTES = 1 << 30
+# Acquisition retry deadline for the Windows non-blocking lock path.
+_WIN_LOCK_DEADLINE_SECONDS = 5.0
+_WIN_LOCK_RETRY_INTERVAL = 0.001
 
 
 # ── Global workspace registry ────────────────────────────────────────────────
@@ -103,18 +112,24 @@ def append_session_event(workspace: Path, session_id: str, event: Dict[str, Any]
             finally:
                 fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
         elif _HAS_MSVCRT:
-            try:
-                msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
-            except OSError:
-                pass
+            locked = False
+            deadline = time.monotonic() + _WIN_LOCK_DEADLINE_SECONDS
+            while time.monotonic() < deadline:
+                try:
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, _WIN_LOCK_BYTES)
+                    locked = True
+                    break
+                except OSError:
+                    time.sleep(_WIN_LOCK_RETRY_INTERVAL)
             try:
                 handle.write(line)
                 handle.flush()
             finally:
-                try:
-                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
-                except OSError:
-                    pass
+                if locked:
+                    try:
+                        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, _WIN_LOCK_BYTES)
+                    except OSError:
+                        pass
         else:
             handle.write(line)
             handle.flush()


### PR DESCRIPTION
## Summary

- `warden/store.py:append_session_event` did an unsynchronized append to per-session `.jsonl` logs. POSIX `O_APPEND` is only atomic for writes <= `PIPE_BUF` (4 KiB on Linux), but Warden hooks routinely log payloads well past that (Read/Bash results, file diffs hit 10-80 KiB), so two hooks firing in parallel splice each other's writes and produce a single line containing two concatenated JSON objects.
- `read_session_events` then raised `json.decoder.JSONDecodeError: Extra data: line 1 column N` because it assumed every line was a single object. The crash surfaced to the agent as a `hook_non_blocking_error` attachment, and in some chained-hook flows the malformed payload reached the upstream model API and was rejected with `400 invalid JSON: unexpected end of JSON input`.

## Repro (observed in the wild)

In a Claude Code workspace under heavy use, the per-workspace log accumulated 13 corrupted lines ranging from 22 KB to 66 KB. Sample:

```
json.decoder.JSONDecodeError: Extra data: line 1 column 15714 (char 15713)
File "warden/store.py", line 94, in <listcomp>
  return [json.loads(line) for line in handle.read().splitlines() if line.strip()]
```

Inspection of the byte at that offset shows `...} false\n}\n"}{"ts": null, "ses...` — two objects glued together with no newline.

## Fix

- Writer: wrap each append in an exclusive `flock` (POSIX) or `msvcrt.locking` (Windows) so concurrent writers serialize. Falls back to plain write only if neither is available.
- Reader: switch to `JSONDecoder.raw_decode` so a line containing N concatenated objects yields N events instead of crashing, and trailing garbage from a partial write is skipped. This recovers data in already-corrupt logs without manual editing.

## Test plan

- [x] New `tests/test_store_concurrent.py`:
  - 8 threads x 50 appends of 8 KB payloads each — all 400 events round-trip and every line on disk parses as a single object.
  - Reader recovers two concatenated objects on one line.
  - Reader skips trailing non-JSON garbage.
- [x] Full existing suite passes: `python3 -m unittest discover -s tests` -> 242 passed.

## Notes

- Lock is advisory; safe because every Warden writer goes through `append_session_event`.
- Reader change is backward-compatible: well-formed logs parse identically; only previously-fatal inputs now succeed.