### PR TITLE
Add IAM layer for named agent identity and permission profiles

### DIFF
--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -167,6 +167,54 @@ _SCRIPT_PATTERNS.append((
 
 ---
 
+## Config Hardening
+
+Install-time scoring only fires when the install command actually goes through `immunity`. If something invokes `npm install` directly (a CI step, an IDE plugin, an agent that doesn't honour the alias), the runtime gate is bypassed.
+
+`immunity harden` closes that gap by hardening the package manager's own config files. It runs before any install happens and applies settings the package manager itself enforces.
+
+```bash
+immunity harden              # apply hardening to the current directory
+immunity harden --dry-run    # preview without writing
+immunity harden <path>       # harden a specific project root
+```
+
+What it does for each ecosystem detected in the project root:
+
+| File | Trigger | Settings applied |
+|---|---|---|
+| `.npmrc` | `package.json` present | `ignore-scripts=true`, `save-exact=true`, `audit=true` |
+| `.yarnrc` | file present | `--ignore-scripts true` |
+| `.yarnrc.yml` | file present | `enableScripts: false` |
+| `pip.conf` | `requirements.txt` / `pyproject.toml` / `setup.py` / `setup.cfg` | `no-input=true`, `disable-pip-version-check=true` |
+| `.cargo/config.toml` | `Cargo.toml` present | `[net] retry=2`, `git-fetch-with-cli=true` |
+
+Existing keys are never overwritten — if you've already set `save-exact=false` for a reason, the hardener leaves it and reports it. New settings are appended under a `# immunity harden` comment so they're easy to identify and remove later.
+
+### Why these settings
+
+**`ignore-scripts` / `enableScripts: false`** is the single highest-impact rule. Every npm supply chain attack in [`supplychain/ioc.py`](../supplychain/ioc.py) — mini-shai-hulud, the AntV hijacked-maintainer wave, the PyPI mistralai/guardrails-ai variant — delivered its payload via a `preinstall` or `postinstall` hook. Disabling lifecycle scripts at the config layer neutralises that vector regardless of whether `immunity` is in the call path.
+
+**`save-exact=true`** is the closest thing to age-gating that npm offers natively. With the default SemVer caret ranges, `npm install express` writes `"express": "^4.18.2"` and a fresh `npm install` on a teammate's machine can resolve to any 4.x version published since — including a hijacked one published an hour ago. Pinning exact versions means the lockfile is the source of truth and new versions only enter the project when someone explicitly bumps them.
+
+**`git-fetch-with-cli=true`** for Cargo routes git dependencies through your system `git` binary instead of cargo's built-in libgit2 fetcher. This respects your existing `.gitconfig`, SSH agent, and credential helpers — and makes git-based supply chain probes (private repo enumeration, malformed URL handling) the responsibility of a more battle-tested tool.
+
+### Hardening + runtime scoring
+
+The config hardening and the runtime scorer are complementary, not redundant:
+
+- **Hardening** narrows the attack surface for *any* install (`npm install` direct, CI, agent without alias).
+- **Runtime scoring** still catches the things hardening can't: a published-2-days-ago malicious package that has no install scripts but is named to typosquat a popular library, or a package whose name matches the IOC database.
+
+Run `immunity harden` once when bootstrapping a project, and use the `immunity` wrapper for installs. The two together give you both a static gate (what the package manager itself enforces) and a dynamic gate (what the immunity scorer rejects).
+
+### Caveats
+
+- `pip.conf` is not auto-read from the project root. Activate with `export PIP_CONFIG_FILE=pip.conf` or place it at `$VIRTUAL_ENV/pip.conf` after creating the venv. The hardener prints this reminder.
+- `ignore-scripts` will break packages that legitimately need install scripts (e.g. `node-gyp` native modules). Allow them per-package via `npm rebuild <pkg> --foreground-scripts` or pnpm's `onlyBuiltDependencies` allowlist in `package.json`.
+
+---
+
 ## Architecture
 
 ```

--- a/supplychain/cli.py
+++ b/supplychain/cli.py
@@ -155,6 +155,10 @@ def main() -> None:
     if str(_REPO_ROOT) not in sys.path:
         sys.path.insert(0, str(_REPO_ROOT))
 
+    if argv[0] == "harden":
+        _cmd_harden(argv[1:])
+        return
+
     from supplychain.ecosystems.detector import detect_install
     event = detect_install(argv)
 
@@ -204,18 +208,39 @@ def main() -> None:
     _exec(argv)
 
 
+def _cmd_harden(args: List[str]) -> None:
+    """Scan the project for package manager configs and apply hardening."""
+    from supplychain.hardener import harden_project, print_harden_report
+
+    dry_run = "--dry-run" in args or "-n" in args
+    path_args = [a for a in args if not a.startswith("-")]
+    root = Path(path_args[0]).resolve() if path_args else Path.cwd()
+
+    if not root.is_dir():
+        sys.stderr.write(f"immunity harden: not a directory: {root}\n")
+        sys.exit(2)
+
+    results = harden_project(root, dry_run=dry_run)
+    print_harden_report(results, root, dry_run=dry_run)
+
+
 def _usage() -> None:
     print(f"  {_c('immunity', _BOLD)} — AI-native supply chain enforcement")
     print()
     print("  Usage: immunity <command> [args...]")
     print()
-    print("  Examples:")
+    print("  Install interception:")
     print("    immunity npm install express")
     print("    immunity pip install requests numpy")
     print("    immunity pnpm add lodash")
     print("    immunity uv add fastapi")
     print("    immunity cargo add serde")
     print("    immunity go get github.com/some/pkg")
+    print()
+    print("  Config hardening:")
+    print("    immunity harden              Apply hardening to project configs")
+    print("    immunity harden --dry-run    Preview without writing")
+    print("    immunity harden <path>       Harden a specific project root")
     print()
     print("  Non-install commands pass through transparently.")
     print()

--- a/supplychain/hardener.py
+++ b/supplychain/hardener.py
@@ -1,0 +1,391 @@
+"""Package manager config hardener.
+
+`immunity harden [--dry-run]` scans the project root for package manager
+manifests, detects existing configs, and applies security hardening that
+shrinks the install-script attack surface and tightens version pinning to
+complement immunity's runtime age-gate checks.
+
+Supported targets:
+  .npmrc               npm / pnpm / bun
+  .yarnrc              Yarn Classic
+  .yarnrc.yml          Yarn Berry (2/3/4)
+  pip.conf             pip  (requires PIP_CONFIG_FILE=pip.conf or venv)
+  .cargo/config.toml   Cargo / Rust
+"""
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+
+# ── Colour helpers (same palette as cli.py) ───────────────────────────────────
+
+_RED    = "\033[0;31m"
+_YELLOW = "\033[1;33m"
+_GREEN  = "\033[0;32m"
+_CYAN   = "\033[0;36m"
+_DIM    = "\033[37m"
+_BOLD   = "\033[1m"
+_RESET  = "\033[0m"
+
+
+def _c(text: str, colour: str) -> str:
+    if sys.stdout.isatty():
+        return f"{colour}{text}{_RESET}"
+    return text
+
+
+# ── Data types ────────────────────────────────────────────────────────────────
+
+@dataclass
+class HardeningChange:
+    key: str
+    value: str
+    reason: str
+
+
+@dataclass
+class HardeningResult:
+    path: Path
+    ecosystem: str
+    created: bool
+    applied: List[HardeningChange] = field(default_factory=list)
+    already_set: List[str] = field(default_factory=list)
+    notes: List[str] = field(default_factory=list)
+
+    @property
+    def any_changes(self) -> bool:
+        return bool(self.applied)
+
+
+# ── String helpers ────────────────────────────────────────────────────────────
+
+def _append_block(existing: str, block: str) -> str:
+    """Append block to existing content with proper newline separation."""
+    content = existing
+    if content and not content.endswith("\n"):
+        content += "\n"
+    if content:
+        content += "\n"
+    return content + block + "\n"
+
+
+# ── .npmrc  (npm / pnpm / bun) ────────────────────────────────────────────────
+
+_NPMRC_RULES: List[Tuple[str, str, str]] = [
+    (
+        "ignore-scripts", "true",
+        "blocks preinstall/postinstall lifecycle scripts — the primary delivery vector"
+        " in every npm supply chain attack in the IOC database (mini-shai-hulud, AntV, etc.)",
+    ),
+    (
+        "save-exact", "true",
+        "pins exact versions on install — SemVer ranges can silently resolve to a newly"
+        " published version between writing a manifest and the next fresh install",
+    ),
+    (
+        "audit", "true",
+        "ensures npm audit runs on every install",
+    ),
+]
+
+
+def _npmrc_has(content: str, key: str, value: str) -> bool:
+    return bool(re.search(
+        rf"^\s*{re.escape(key)}\s*=\s*{re.escape(value)}\s*$",
+        content, re.MULTILINE | re.IGNORECASE,
+    ))
+
+
+def _npmrc_key_exists(content: str, key: str) -> bool:
+    return bool(re.search(
+        rf"^\s*{re.escape(key)}\s*=",
+        content, re.MULTILINE | re.IGNORECASE,
+    ))
+
+
+def _harden_npmrc(root: Path, dry_run: bool) -> Optional[HardeningResult]:
+    path = root / ".npmrc"
+    if not (root / "package.json").exists() and not path.exists():
+        return None
+
+    existing = path.read_text() if path.exists() else ""
+    created = not path.exists()
+    new_lines: List[str] = []
+    applied: List[HardeningChange] = []
+    already_set: List[str] = []
+
+    for key, value, reason in _NPMRC_RULES:
+        if _npmrc_has(existing, key, value):
+            already_set.append(f"{key}={value}")
+        elif _npmrc_key_exists(existing, key):
+            already_set.append(f"{key} (custom value — not overwritten)")
+        else:
+            new_lines.append(f"{key}={value}")
+            applied.append(HardeningChange(key=key, value=value, reason=reason))
+
+    if new_lines and not dry_run:
+        block = "# immunity harden\n" + "\n".join(new_lines)
+        path.write_text(_append_block(existing, block))
+
+    notes: List[str] = []
+    ignore_scripts_active = (
+        any(c.key == "ignore-scripts" for c in applied)
+        or "ignore-scripts=true" in already_set
+    )
+    if ignore_scripts_active:
+        notes.append(
+            "ignore-scripts blocks install hooks globally. Some packages legitimately need them"
+            " (node-gyp native modules). Allow per-package via 'npm rebuild <pkg> --foreground-scripts'"
+            " or pnpm's onlyBuiltDependencies allowlist."
+        )
+
+    return HardeningResult(
+        path=path, ecosystem="npm / pnpm / bun",
+        created=created, applied=applied, already_set=already_set, notes=notes,
+    )
+
+
+# ── .yarnrc  (Yarn Classic) ───────────────────────────────────────────────────
+
+def _harden_yarnrc_classic(root: Path, dry_run: bool) -> Optional[HardeningResult]:
+    path = root / ".yarnrc"
+    if not path.exists():
+        return None
+
+    existing = path.read_text()
+    applied: List[HardeningChange] = []
+    already_set: List[str] = []
+
+    if re.search(r"^--ignore-scripts\s+true\s*$", existing, re.MULTILINE | re.IGNORECASE):
+        already_set.append("--ignore-scripts true")
+    elif re.search(r"^--ignore-scripts\b", existing, re.MULTILINE | re.IGNORECASE):
+        already_set.append("--ignore-scripts (custom value — not overwritten)")
+    else:
+        applied.append(HardeningChange(
+            key="--ignore-scripts", value="true",
+            reason="blocks Yarn Classic lifecycle scripts",
+        ))
+        if not dry_run:
+            block = "# immunity harden\n--ignore-scripts true"
+            path.write_text(_append_block(existing, block))
+
+    return HardeningResult(
+        path=path, ecosystem="Yarn Classic",
+        created=False, applied=applied, already_set=already_set,
+    )
+
+
+# ── .yarnrc.yml  (Yarn Berry 2/3/4) ──────────────────────────────────────────
+
+def _harden_yarnrc_yml(root: Path, dry_run: bool) -> Optional[HardeningResult]:
+    path = root / ".yarnrc.yml"
+    if not path.exists():
+        return None
+
+    existing = path.read_text()
+    applied: List[HardeningChange] = []
+    already_set: List[str] = []
+
+    if re.search(r"^\s*enableScripts\s*:\s*false\s*$", existing, re.MULTILINE | re.IGNORECASE):
+        already_set.append("enableScripts: false")
+    elif re.search(r"^\s*enableScripts\s*:", existing, re.MULTILINE | re.IGNORECASE):
+        already_set.append("enableScripts (custom value — not overwritten)")
+    else:
+        applied.append(HardeningChange(
+            key="enableScripts", value="false",
+            reason="disables Yarn Berry lifecycle scripts (Berry's equivalent of npm ignore-scripts)",
+        ))
+        if not dry_run:
+            block = "# immunity harden\nenableScripts: false"
+            path.write_text(_append_block(existing, block))
+
+    return HardeningResult(
+        path=path, ecosystem="Yarn Berry",
+        created=False, applied=applied, already_set=already_set,
+    )
+
+
+# ── pip.conf  (pip / uv) ─────────────────────────────────────────────────────
+
+_PIPCONF_RULES: List[Tuple[str, str, str]] = [
+    (
+        "no-input", "true",
+        "prevents pip from blocking on prompts in CI/automated environments",
+    ),
+    (
+        "disable-pip-version-check", "true",
+        "suppresses upgrade prompts that could pull a newer pip mid-pipeline",
+    ),
+]
+
+_PIPCONF_MANIFESTS = ("requirements.txt", "pyproject.toml", "setup.py", "setup.cfg")
+
+
+def _harden_pip(root: Path, dry_run: bool) -> Optional[HardeningResult]:
+    has_manifest = any((root / f).exists() for f in _PIPCONF_MANIFESTS)
+    path = root / "pip.conf"
+    if not has_manifest and not path.exists():
+        return None
+
+    existing = path.read_text() if path.exists() else ""
+    created = not path.exists()
+    new_lines: List[str] = []
+    applied: List[HardeningChange] = []
+    already_set: List[str] = []
+
+    for key, value, reason in _PIPCONF_RULES:
+        if re.search(rf"^\s*{re.escape(key)}\s*=", existing, re.MULTILINE | re.IGNORECASE):
+            already_set.append(key)
+        else:
+            new_lines.append(f"{key} = {value}")
+            applied.append(HardeningChange(key=key, value=value, reason=reason))
+
+    if new_lines and not dry_run:
+        block = "[global]\n# immunity harden\n" + "\n".join(new_lines)
+        path.write_text(_append_block(existing, block))
+
+    notes = [
+        "pip.conf is not auto-read from the project root. Activate with:"
+        "  export PIP_CONFIG_FILE=pip.conf"
+        "  (or copy to $VIRTUAL_ENV/pip.conf after creating a venv).",
+        "For stronger pip hardening, generate hashes (pip-compile --generate-hashes)"
+        " and set require-hashes = true under [install] in pip.conf.",
+    ]
+
+    return HardeningResult(
+        path=path, ecosystem="pip",
+        created=created, applied=applied, already_set=already_set, notes=notes,
+    )
+
+
+# ── .cargo/config.toml  (Cargo / Rust) ───────────────────────────────────────
+
+_CARGO_NET_BLOCK = (
+    "[net]\n"
+    "retry = 2\n"
+    "git-fetch-with-cli = true\n"
+)
+
+
+def _harden_cargo(root: Path, dry_run: bool) -> Optional[HardeningResult]:
+    if not (root / "Cargo.toml").exists():
+        return None
+
+    config_path = root / ".cargo" / "config.toml"
+    existing = config_path.read_text() if config_path.exists() else ""
+    created = not config_path.exists()
+    applied: List[HardeningChange] = []
+    already_set: List[str] = []
+
+    if re.search(r"^\[net\]", existing, re.MULTILINE):
+        already_set.append("[net] section (manual review recommended)")
+    else:
+        applied.append(HardeningChange(
+            key="[net]", value="retry=2, git-fetch-with-cli=true",
+            reason=(
+                "retry=2 handles transient network failures; "
+                "git-fetch-with-cli routes git deps through your system git "
+                "(respects gitconfig credentials and SSH keys, instead of cargo's "
+                "built-in libgit2 fetcher)"
+            ),
+        ))
+        if not dry_run:
+            if not config_path.parent.exists():
+                config_path.parent.mkdir(parents=True, exist_ok=True)
+            block = "# immunity harden\n" + _CARGO_NET_BLOCK.rstrip()
+            config_path.write_text(_append_block(existing, block))
+
+    return HardeningResult(
+        path=config_path, ecosystem="Cargo",
+        created=created, applied=applied, already_set=already_set,
+    )
+
+
+# ── Orchestrator ──────────────────────────────────────────────────────────────
+
+def harden_project(root: Path, dry_run: bool = False) -> List[HardeningResult]:
+    """Scan root for package manager configs and apply hardening.
+
+    Returns one HardeningResult per config examined or created.
+    If dry_run is True, no files are written.
+    """
+    candidates = [
+        _harden_npmrc(root, dry_run),
+        _harden_yarnrc_classic(root, dry_run),
+        _harden_yarnrc_yml(root, dry_run),
+        _harden_pip(root, dry_run),
+        _harden_cargo(root, dry_run),
+    ]
+    return [r for r in candidates if r is not None]
+
+
+# ── Output ────────────────────────────────────────────────────────────────────
+
+def print_harden_report(
+    results: List[HardeningResult], root: Path, dry_run: bool
+) -> None:
+    print()
+    suffix = _c("  [dry run — no files written]", _YELLOW) if dry_run else ""
+    print(f"  {_c('IMMUNITY', _BOLD)}  harden  {_c(str(root), _DIM)}{suffix}")
+    print(f"  {_c('─' * 60, _DIM)}")
+    print()
+
+    if not results:
+        print(f"  {_c('No package manager manifests found in this directory.', _DIM)}")
+        print(f"  {_c('Looked for: package.json, .yarnrc(.yml), Cargo.toml, requirements.txt, pyproject.toml.', _DIM)}")
+        print()
+        return
+
+    total_applied = 0
+    total_created = 0
+
+    for r in results:
+        rel = _display_path(r.path, root)
+        if r.created:
+            state = _c("CREATED", _CYAN)
+        elif r.applied:
+            state = _c("UPDATED", _GREEN)
+        else:
+            state = _c("OK", _DIM)
+        print(f"  {_c(rel, _BOLD)}  {_c(f'[{r.ecosystem}]', _DIM)}  {state}")
+
+        for change in r.applied:
+            verb = "would set" if dry_run else "set"
+            label = f"{change.key}={change.value}" if not change.key.startswith("[") else change.key
+            print(f"    {_c('+', _GREEN)} {verb} {_c(label, _BOLD)}")
+            print(f"        {_c(change.reason, _DIM)}")
+
+        for entry in r.already_set:
+            print(f"    {_c('=', _DIM)} {entry}")
+
+        for note in r.notes:
+            print(f"    {_c('note:', _YELLOW)} {note}")
+
+        print()
+        total_applied += len(r.applied)
+        if r.created:
+            total_created += 1
+
+    total_configs = len(results)
+    changed = sum(1 for r in results if r.any_changes)
+    if dry_run:
+        print(f"  {_c(f'{total_applied} setting(s) would be applied across {total_configs} config(s).', _BOLD)}")
+        print(f"  {_c('Remove --dry-run to write changes.', _DIM)}")
+    else:
+        created_str = f", {total_created} created" if total_created else ""
+        if total_applied == 0:
+            print(f"  {_c('All discovered configs are already hardened.', _GREEN)}")
+        else:
+            print(f"  {_c(f'{total_applied} setting(s) applied across {changed} config(s){created_str}.', _BOLD)}")
+    print()
+
+
+def _display_path(path: Path, root: Path) -> str:
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return str(path)

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -43,12 +43,21 @@ agents:
     deny_tools: []
     deny_network: true
     allowed_paths: ["docs/**"]
+  edit-only:
+    allowed_tools: [Read, Edit]
+    deny_tools: [Write]
+    deny_network: true
+    allowed_paths: ["**"]
 """
 
 
 class _IamTestBase(unittest.TestCase):
     def setUp(self):
         self.tmp = Path(tempfile.mkdtemp())
+        # Hermetic: drop the path+mtime config memo and the warn-once state so
+        # test order can't leak a cached config or a suppressed warning.
+        iam_mod._CONFIG_CACHE.clear()
+        iam_mod._WARNED_UNKNOWN_IDS.clear()
         # Isolate from any real ~/.prismor/iam.yaml on the test machine.
         self._orig_global = iam_mod._GLOBAL_IAM_PATH
         iam_mod._GLOBAL_IAM_PATH = self.tmp / "no-such-global-iam.yaml"
@@ -146,6 +155,39 @@ class TestIamBlockingDecision(_IamTestBase):
     def test_allowed_network_does_not_block(self):
         os.environ["WARDEN_AGENT_ID"] = "researcher"
         ev = {"type": "network", "url": "https://api.example.com", "agent_event": "PreToolUse"}
+        self.assertIsNone(iam_mod.check_iam(workspace=self.tmp, event=ev, session_id="s"))
+
+
+class TestDenyToolsEnforcement(_IamTestBase):
+    """deny_tools must take precedence over allowed_tools.
+
+    Regression for the review finding: ``edit-only`` allows Edit but denies
+    Write, yet a file_write was allowed because the checker only asked whether
+    *any* write-family tool was allowed and never consulted deny_tools.
+    """
+
+    def test_denied_write_blocks_when_tool_unknown(self):
+        # No metadata.tool_name → a file_write resolves to the literal Write,
+        # which edit-only denies. Must block even though Edit is allowed.
+        os.environ["WARDEN_AGENT_ID"] = "edit-only"
+        ev = {"type": "file_write", "path": "main.py", "agent_event": "PreToolUse"}
+        f = iam_mod.check_iam(workspace=self.tmp, event=ev, session_id="s")
+        self.assertIsNotNone(f)
+        self.assertEqual(f["category"], "iam")
+        self.assertIsNotNone(should_block([f], ev, block_categories=self._block_categories()))
+
+    def test_denied_write_blocks_via_metadata_tool_name(self):
+        # An explicit Write tool (from the hook normalizer) is denied.
+        os.environ["WARDEN_AGENT_ID"] = "edit-only"
+        ev = {"type": "file_write", "path": "main.py",
+              "metadata": {"tool_name": "Write"}, "agent_event": "PreToolUse"}
+        self.assertIsNotNone(iam_mod.check_iam(workspace=self.tmp, event=ev, session_id="s"))
+
+    def test_allowed_edit_passes_via_metadata_tool_name(self):
+        # The same profile permits Edit; the concrete tool from metadata wins.
+        os.environ["WARDEN_AGENT_ID"] = "edit-only"
+        ev = {"type": "file_write", "path": "main.py",
+              "metadata": {"tool_name": "Edit"}, "agent_event": "PreToolUse"}
         self.assertIsNone(iam_mod.check_iam(workspace=self.tmp, event=ev, session_id="s"))
 
 

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -1,0 +1,189 @@
+"""Tests for the Warden IAM enforcement layer.
+
+Regression guard for the PR #41 review finding: ``check_iam()`` produced a
+finding with ``category="iam"``, but ``should_block()`` silently dropped it
+because ``iam`` was missing from the policy ``block_categories`` — making
+enforce-mode IAM a no-op. The ``iam check`` CLI masked this by exiting 2
+directly, so the manual test plan passed while live enforcement did nothing.
+
+These tests exercise the real blocking path (``should_block`` + a full
+``hook-dispatch`` subprocess), not ``iam check``.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from warden import iam as iam_mod
+from warden.hooks import should_block
+from warden.policy_engine import PolicyEngine
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_PROFILES = """\
+agents:
+  readonly-bot:
+    allowed_tools: [Read]
+    deny_tools: []
+    deny_network: true
+    allowed_paths: ["**"]
+  researcher:
+    allowed_tools: [Read, WebFetch, WebSearch]
+    deny_tools: [Bash, Write, Edit]
+    deny_network: false
+    allowed_paths: ["**"]
+  scoped-reader:
+    allowed_tools: [Read]
+    deny_tools: []
+    deny_network: true
+    allowed_paths: ["docs/**"]
+"""
+
+
+class _IamTestBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        # Isolate from any real ~/.prismor/iam.yaml on the test machine.
+        self._orig_global = iam_mod._GLOBAL_IAM_PATH
+        iam_mod._GLOBAL_IAM_PATH = self.tmp / "no-such-global-iam.yaml"
+        proj = self.tmp / ".prismor-warden"
+        proj.mkdir(parents=True, exist_ok=True)
+        (proj / "iam.yaml").write_text(_PROFILES, encoding="utf-8")
+        self._orig_env = os.environ.get("WARDEN_AGENT_ID")
+
+    def tearDown(self):
+        iam_mod._GLOBAL_IAM_PATH = self._orig_global
+        if self._orig_env is None:
+            os.environ.pop("WARDEN_AGENT_ID", None)
+        else:
+            os.environ["WARDEN_AGENT_ID"] = self._orig_env
+
+    def _block_categories(self):
+        # Mirror cli.py: block decision uses the policy's block_categories.
+        return set(PolicyEngine(workspace=self.tmp).block_categories)
+
+
+class TestCheckIamFinding(_IamTestBase):
+    def test_denied_write_produces_iam_finding(self):
+        os.environ["WARDEN_AGENT_ID"] = "readonly-bot"
+        ev = {"type": "file_write", "path": "main.py", "agent_event": "PreToolUse"}
+        f = iam_mod.check_iam(workspace=self.tmp, event=ev, session_id="s")
+        self.assertIsNotNone(f)
+        self.assertEqual(f["category"], "iam")
+
+    def test_allowed_read_passes(self):
+        os.environ["WARDEN_AGENT_ID"] = "readonly-bot"
+        ev = {"type": "file_read", "path": "main.py", "agent_event": "PreToolUse"}
+        self.assertIsNone(iam_mod.check_iam(workspace=self.tmp, event=ev, session_id="s"))
+
+    def test_no_agent_id_means_no_restriction(self):
+        os.environ.pop("WARDEN_AGENT_ID", None)
+        ev = {"type": "file_write", "path": "main.py", "agent_event": "PreToolUse"}
+        self.assertIsNone(iam_mod.check_iam(workspace=self.tmp, event=ev, session_id="s"))
+
+    def test_unknown_agent_falls_back_to_deny(self):
+        os.environ["WARDEN_AGENT_ID"] = "ghost"
+        ev = {"type": "shell", "command": "ls", "agent_event": "PreToolUse"}
+        f = iam_mod.check_iam(workspace=self.tmp, event=ev, session_id="s")
+        self.assertIsNotNone(f)
+        self.assertEqual(f["category"], "iam")
+
+    def test_project_config_overrides_global(self):
+        # Global defines readonly-bot as allowing writes; project locks it down.
+        iam_mod._GLOBAL_IAM_PATH = self.tmp / "global.yaml"
+        iam_mod._GLOBAL_IAM_PATH.write_text(
+            "agents:\n  readonly-bot:\n    allowed_tools: [Read, Write]\n"
+            "    deny_tools: []\n    deny_network: true\n    allowed_paths: ['**']\n",
+            encoding="utf-8",
+        )
+        os.environ["WARDEN_AGENT_ID"] = "readonly-bot"
+        ev = {"type": "file_write", "path": "main.py", "agent_event": "PreToolUse"}
+        # Project profile (Read only) must win → write is denied.
+        self.assertIsNotNone(iam_mod.check_iam(workspace=self.tmp, event=ev, session_id="s"))
+
+
+class TestIamBlockingDecision(_IamTestBase):
+    """The core regression: iam findings must reach a block verdict."""
+
+    def test_iam_in_default_block_categories(self):
+        self.assertIn("iam", self._block_categories())
+
+    def test_denied_write_blocks(self):
+        os.environ["WARDEN_AGENT_ID"] = "readonly-bot"
+        ev = {"type": "file_write", "path": "main.py", "agent_event": "PreToolUse"}
+        f = iam_mod.check_iam(workspace=self.tmp, event=ev, session_id="s")
+        verdict = should_block([f], ev, block_categories=self._block_categories())
+        self.assertIsNotNone(verdict)
+        self.assertEqual(verdict["category"], "iam")
+
+    def test_denied_shell_blocks(self):
+        os.environ["WARDEN_AGENT_ID"] = "readonly-bot"
+        ev = {"type": "shell", "command": "rm x", "agent_event": "PreToolUse"}
+        f = iam_mod.check_iam(workspace=self.tmp, event=ev, session_id="s")
+        self.assertIsNotNone(should_block([f], ev, block_categories=self._block_categories()))
+
+    def test_denied_network_blocks(self):
+        os.environ["WARDEN_AGENT_ID"] = "readonly-bot"
+        ev = {"type": "network", "url": "https://x", "agent_event": "PreToolUse"}
+        f = iam_mod.check_iam(workspace=self.tmp, event=ev, session_id="s")
+        self.assertIsNotNone(should_block([f], ev, block_categories=self._block_categories()))
+
+    def test_iam_read_denial_blocks_despite_file_read_carveout(self):
+        # scoped-reader may only read docs/**; a read elsewhere is an iam denial
+        # that must block (the file_read carve-out only spares non-iam reads).
+        os.environ["WARDEN_AGENT_ID"] = "scoped-reader"
+        ev = {"type": "file_read", "path": "secrets/key.pem", "agent_event": "PreToolUse"}
+        f = iam_mod.check_iam(workspace=self.tmp, event=ev, session_id="s")
+        self.assertIsNotNone(f)
+        self.assertIsNotNone(should_block([f], ev, block_categories=self._block_categories()))
+
+    def test_allowed_network_does_not_block(self):
+        os.environ["WARDEN_AGENT_ID"] = "researcher"
+        ev = {"type": "network", "url": "https://api.example.com", "agent_event": "PreToolUse"}
+        self.assertIsNone(iam_mod.check_iam(workspace=self.tmp, event=ev, session_id="s"))
+
+
+class TestIamHookDispatchEndToEnd(_IamTestBase):
+    """Drive the real hook-dispatch path in enforce mode (not ``iam check``)."""
+
+    def _dispatch(self, payload, agent_id):
+        env = dict(os.environ)
+        env["WARDEN_AGENT_ID"] = agent_id
+        env["HOME"] = str(self.tmp)  # isolate global ~/.prismor in the subprocess
+        return subprocess.run(
+            [sys.executable, str(REPO_ROOT / "warden" / "cli.py"),
+             "hook-dispatch", "--agent", "claude",
+             "--workspace", str(self.tmp), "--mode", "enforce"],
+            input=json.dumps(payload), capture_output=True, text=True, env=env,
+        )
+
+    def test_enforce_blocks_denied_write(self):
+        payload = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Write",
+            "tool_input": {"file_path": "main.py", "content": "x"},
+            "session_id": "e2e-write",
+        }
+        proc = self._dispatch(payload, "readonly-bot")
+        self.assertEqual(proc.returncode, 2, f"stdout={proc.stdout}\nstderr={proc.stderr}")
+        self.assertIn("iam:readonly-bot", proc.stderr)
+
+    def test_enforce_allows_read(self):
+        payload = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Read",
+            "tool_input": {"file_path": "main.py"},
+            "session_id": "e2e-read",
+        }
+        proc = self._dispatch(payload, "readonly-bot")
+        self.assertEqual(proc.returncode, 0, f"stdout={proc.stdout}\nstderr={proc.stderr}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/warden/cli.py
+++ b/warden/cli.py
@@ -28,6 +28,11 @@ Commands:
   cloak list      List registered placeholder names (never values)
   cloak remove NAME  Delete a registered secret
   cloak status    Show whether cloaking hooks are installed
+  iam list        List all defined agent identities
+  iam init        Create a starter iam.yaml config (~/.prismor/iam.yaml)
+  iam init --scope project  Create per-project .prismor-warden/iam.yaml
+  iam show NAME   Show permission profile for an agent identity
+  iam check NAME --type command --value "rm -rf /"  Test an action against a profile
 """
 from __future__ import annotations
 
@@ -657,6 +662,15 @@ def main() -> None:
         except Exception as _sr_exc:
             sys.stderr.write(f"[warden] scoped enforcement error: {_sr_exc}\n")
 
+        # ── IAM: named agent identity enforcement ────────────────────
+        try:
+            from warden.iam import check_iam as _check_iam
+            _iam_finding = _check_iam(workspace=workspace, event=event, session_id=normalized["sessionId"])
+            if _iam_finding:
+                current_findings.append(_iam_finding)
+        except Exception as _iam_exc:
+            sys.stderr.write(f"[warden] IAM enforcement error: {_iam_exc}\n")
+
         # ── Learning: evasion detection on passing shell events ───────
         if not current_findings and event.get("type") == "shell":
             try:
@@ -713,6 +727,105 @@ def main() -> None:
                 )
             except Exception:
                 pass  # best-effort, don't break the hook
+        return
+
+    # ── iam ────────────────────────────────────────────────────────────
+    if args.command == "iam":
+        from warden.iam import (
+            load_iam_config as _load_iam,
+            get_active_agent_id as _get_agent_id,
+            list_agent_ids as _list_agent_ids,
+            resolve_agent_profile as _resolve_profile,
+            format_iam_profile_box as _fmt_iam,
+            check_iam as _check_iam_cmd,
+            init_global_iam as _init_global_iam,
+            init_project_iam as _init_project_iam,
+        )
+        subcmd = getattr(args, "iam_subcommand", None)
+
+        if subcmd == "init":
+            scope = getattr(args, "scope", "global")
+            if scope == "project":
+                path = _init_project_iam(workspace)
+            else:
+                path = _init_global_iam()
+            print(f"Created IAM config: {path}")
+            print("Edit it to define your agent identities, then set WARDEN_AGENT_ID=<name>.")
+            return
+
+        cfg = _load_iam(workspace)
+        agent_ids = _list_agent_ids(cfg)
+
+        if subcmd == "list" or subcmd is None:
+            active = _get_agent_id()
+            print(f"\n  {_color('Warden IAM', _BOLD)}  agent identities\n")
+            if not agent_ids:
+                print(f"  {_color('No agents defined.', _DIM)}")
+                print(f"  Run: warden iam init\n")
+                return
+            for aid in agent_ids:
+                marker = _color(" ← active", _GREEN) if aid == active else ""
+                print(f"  {_color(aid, _CYAN)}{marker}")
+            if not active:
+                print(f"\n  {_color('Tip:', _DIM)} set WARDEN_AGENT_ID=<name> to activate a profile.")
+            print()
+            return
+
+        if subcmd == "show":
+            agent_id = getattr(args, "agent_id", None)
+            if not agent_id:
+                sys.stderr.write("error: agent_id is required for 'iam show'\n")
+                raise SystemExit(1)
+            profile = _resolve_profile(agent_id, cfg)
+            if profile is None:
+                sys.stderr.write(f"error: agent '{agent_id}' not found in IAM config\n")
+                raise SystemExit(1)
+            print(_fmt_iam(agent_id, profile))
+            return
+
+        if subcmd == "check":
+            agent_id = getattr(args, "agent_id", None)
+            check_type = getattr(args, "type", "command")
+            check_value = getattr(args, "value", None)
+            if not agent_id or not check_value:
+                sys.stderr.write("error: agent_id and --value are required for 'iam check'\n")
+                raise SystemExit(1)
+
+            profile = _resolve_profile(agent_id, cfg)
+            if profile is None:
+                sys.stderr.write(f"error: agent '{agent_id}' not found in IAM config\n")
+                raise SystemExit(1)
+
+            if check_type == "command":
+                event_under_test = {"type": "shell", "command": check_value}
+            elif check_type == "read":
+                event_under_test = {"type": "file_read", "path": check_value}
+            elif check_type == "write":
+                event_under_test = {"type": "file_write", "path": check_value}
+            elif check_type == "network":
+                event_under_test = {"type": "network", "url": check_value}
+            else:
+                event_under_test = {"type": "shell", "command": check_value}
+
+            import os as _os
+            old_val = _os.environ.get("WARDEN_AGENT_ID")
+            _os.environ["WARDEN_AGENT_ID"] = agent_id
+            try:
+                finding = _check_iam_cmd(workspace=workspace, event=event_under_test)
+            finally:
+                if old_val is None:
+                    _os.environ.pop("WARDEN_AGENT_ID", None)
+                else:
+                    _os.environ["WARDEN_AGENT_ID"] = old_val
+
+            if finding:
+                print(_color("BLOCK", _RED) + f"  [{finding['severity']}] {finding['title']}")
+                print(f"  {finding.get('evidence', '')}")
+                raise SystemExit(2)
+            else:
+                print(_color("ALLOW", _GREEN) + f"  agent '{agent_id}' may perform: {check_type} {check_value}")
+            return
+
         return
 
     # ── sweep ──────────────────────────────────────────────────────────
@@ -1365,6 +1478,36 @@ def build_parser() -> argparse.ArgumentParser:
                               help="Reject a candidate rule")
     learn_parser.add_argument("--candidates", action="store_true",
                               help="List pending candidate rules")
+
+    # ── iam ──────────────────────────────────────────────────────────────
+    iam_parser = subparsers.add_parser(
+        "iam",
+        help="Manage agent IAM identities and permission profiles",
+    )
+    iam_subs = iam_parser.add_subparsers(dest="iam_subcommand")
+
+    iam_subs.add_parser("list", help="List all defined agent identities")
+
+    iam_init = iam_subs.add_parser("init", help="Create a starter iam.yaml config")
+    iam_init.add_argument(
+        "--scope",
+        choices=["global", "project"],
+        default="global",
+        help="Write to ~/.prismor/iam.yaml (global) or .prismor-warden/iam.yaml (project)",
+    )
+
+    iam_show = iam_subs.add_parser("show", help="Show permission profile for an agent identity")
+    iam_show.add_argument("agent_id", help="Agent identity name")
+
+    iam_check = iam_subs.add_parser("check", help="Test whether an agent identity can perform an action")
+    iam_check.add_argument("agent_id", help="Agent identity name")
+    iam_check.add_argument(
+        "--type",
+        choices=["command", "read", "write", "network"],
+        default="command",
+        help="Event type to test (default: command)",
+    )
+    iam_check.add_argument("--value", required=True, help="Value to test (command, path, or URL)")
 
     return parser
 

--- a/warden/default_policy.yaml
+++ b/warden/default_policy.yaml
@@ -23,6 +23,7 @@ settings:
     - persistence
     - security_bypass
     - dependency_risk
+    - iam
 
   # Egress allowlist — when set, any outbound network call to a domain NOT in
   # this list triggers a warning. Supports wildcards: "*.github.com" matches

--- a/warden/hooks.py
+++ b/warden/hooks.py
@@ -150,7 +150,13 @@ def should_block(
     categories = block_categories if block_categories is not None else _default_block_categories()
     for finding in findings:
         if finding.get("category") in categories:
-            if event.get("type") == "file_read" and finding.get("category") != "secret_access":
+            # Reads are generally safe, so they only block for secret access —
+            # except for IAM, where an operator has explicitly scoped which
+            # paths/tools an identity may read, and that intent must be honored.
+            if (
+                event.get("type") == "file_read"
+                and finding.get("category") not in ("secret_access", "iam")
+            ):
                 continue
             return finding
     return None

--- a/warden/iam.py
+++ b/warden/iam.py
@@ -1,0 +1,222 @@
+"""Warden IAM — named agent identity and permission profiles.
+
+Agent identities are defined in YAML config files. Config resolution order:
+  1. ~/.prismor/iam.yaml          (global, user-level)
+  2. .prismor-warden/iam.yaml     (per-project, takes precedence)
+
+The active agent identity is set via the WARDEN_AGENT_ID environment variable.
+If unset, no IAM restrictions are applied beyond the base Warden policy.
+
+Config format:
+  agents:
+    readonly-bot:
+      allowed_tools: [Read]
+      deny_tools: []
+      deny_network: true
+      allowed_paths: ["**"]
+
+    researcher:
+      allowed_tools: [Read, WebFetch, WebSearch]
+      deny_tools: [Bash, Write, Edit]
+      deny_network: false
+      allowed_paths: ["**"]
+
+    code-reviewer:
+      allowed_tools: [Read, Bash]
+      deny_tools: [Write, Edit, WebFetch, WebSearch]
+      deny_network: true
+      allowed_paths: ["**"]
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+_GLOBAL_IAM_PATH = Path.home() / ".prismor" / "iam.yaml"
+_PROJECT_IAM_FILENAME = "iam.yaml"
+
+_STARTER_CONFIG = """\
+# Prismor Warden — IAM agent identity config
+# Set WARDEN_AGENT_ID=<name> before launching an agent to apply its profile.
+# Per-project overrides go in .prismor-warden/iam.yaml
+
+agents:
+  # Read-only agent: can only inspect files, no writes or network.
+  readonly-bot:
+    allowed_tools: [Read]
+    deny_tools: []
+    deny_network: true
+    allowed_paths: ["**"]
+
+  # Research agent: can read and fetch URLs, but cannot write files.
+  researcher:
+    allowed_tools: [Read, WebFetch, WebSearch]
+    deny_tools: [Bash, Write, Edit, MultiEdit]
+    deny_network: false
+    allowed_paths: ["**"]
+
+  # Code reviewer: can read and run shell commands, but cannot write.
+  code-reviewer:
+    allowed_tools: [Read, Bash]
+    deny_tools: [Write, Edit, MultiEdit, WebFetch, WebSearch]
+    deny_network: true
+    allowed_paths: ["**"]
+
+  # Full-access agent: no IAM restrictions (still subject to base policy).
+  # Remove or rename to disable unrestricted access.
+  trusted-agent:
+    allowed_tools: [Read, Write, Edit, MultiEdit, Bash, WebFetch, WebSearch]
+    deny_tools: []
+    deny_network: false
+    allowed_paths: ["**"]
+"""
+
+
+# ── Config loading ─────────────────────────────────────────────────────────
+
+def _load_yaml(path: Path) -> Optional[Dict[str, Any]]:
+    if not path.exists():
+        return None
+    try:
+        import yaml
+        return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except Exception as exc:
+        sys.stderr.write(f"[warden/iam] failed to load {path}: {exc}\n")
+        return None
+
+
+def load_iam_config(workspace: Optional[Path] = None) -> Dict[str, Any]:
+    """Load IAM config. Project-level agents override global agents."""
+    config: Dict[str, Any] = {}
+
+    global_cfg = _load_yaml(_GLOBAL_IAM_PATH)
+    if global_cfg:
+        config.update(global_cfg)
+
+    if workspace:
+        project_path = workspace / ".prismor-warden" / _PROJECT_IAM_FILENAME
+        project_cfg = _load_yaml(project_path)
+        if project_cfg:
+            project_agents = project_cfg.get("agents", {})
+            if project_agents:
+                config.setdefault("agents", {}).update(project_agents)
+
+    return config
+
+
+# ── Identity resolution ────────────────────────────────────────────────────
+
+def get_active_agent_id() -> Optional[str]:
+    """Return the active agent identity from WARDEN_AGENT_ID, or None."""
+    return os.environ.get("WARDEN_AGENT_ID") or None
+
+
+def resolve_agent_profile(agent_id: str, config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Look up the permission profile for a named agent identity."""
+    return config.get("agents", {}).get(agent_id)
+
+
+def list_agent_ids(config: Dict[str, Any]) -> List[str]:
+    return sorted(config.get("agents", {}).keys())
+
+
+# ── Enforcement ────────────────────────────────────────────────────────────
+
+_DENY_ALL_PROFILE: Dict[str, Any] = {
+    "allowed_tools": ["Read"],
+    "deny_tools": [],
+    "deny_network": True,
+    "allowed_paths": ["**"],
+}
+
+
+def check_iam(
+    workspace: Optional[Path] = None,
+    event: Optional[Dict[str, Any]] = None,
+    session_id: str = "",
+) -> Optional[Dict[str, Any]]:
+    """Check an event against the IAM profile for the active agent identity.
+
+    Returns a finding dict if the event is blocked, None if allowed or if no
+    WARDEN_AGENT_ID is set.
+    """
+    agent_id = get_active_agent_id()
+    if not agent_id or event is None:
+        return None
+
+    config = load_iam_config(workspace)
+    profile = resolve_agent_profile(agent_id, config)
+
+    if profile is None:
+        sys.stderr.write(
+            f"[warden/iam] unknown agent identity '{agent_id}' — applying deny-all policy.\n"
+            f"             Add '{agent_id}' to ~/.prismor/iam.yaml or .prismor-warden/iam.yaml\n"
+        )
+        profile = _DENY_ALL_PROFILE
+
+    from warden.scoped_agent import check_scoped_rules
+    finding = check_scoped_rules(profile, event, session_id=session_id)
+    if finding:
+        finding["ruleId"] = "iam"
+        finding["category"] = "iam"
+        finding["id"] = f"{session_id}:iam:{agent_id}"
+        finding["title"] = finding["title"].replace(
+            "[scoped agent]", f"[iam:{agent_id}]"
+        )
+    return finding
+
+
+# ── Display ────────────────────────────────────────────────────────────────
+
+_BOLD = "\033[1m"
+_CYAN = "\033[0;36m"
+_GREEN = "\033[0;32m"
+_DIM = "\033[37m"
+_NC = "\033[0m"
+
+
+def format_iam_profile_box(agent_id: str, profile: Dict[str, Any]) -> str:
+    """Format an IAM profile as an ASCII box for stderr display."""
+    allowed = ", ".join(profile.get("allowed_tools", []))
+    paths = ", ".join(profile.get("allowed_paths", ["**"]))
+    denied = ", ".join(profile.get("deny_tools", []))
+    network = "denied" if profile.get("deny_network", True) else "allowed"
+
+    content_lines = [
+        f"  agent:          {agent_id}",
+        f"  allowed_tools:  [{allowed}]",
+        f"  allowed_paths:  [{paths}]",
+        f"  deny_tools:     [{denied}]",
+        f"  deny_network:   {network}",
+    ]
+
+    max_width = max(len(line) for line in content_lines) + 4
+    border = max_width + 2
+
+    lines = []
+    header = " Warden IAM — active agent policy "
+    pad = border - 2 - len(header)
+    lines.append(f"{_CYAN}┌─{header}" + "─" * pad + f"┐{_NC}")
+    for cl in content_lines:
+        padding = border - 2 - len(cl)
+        lines.append(f"{_CYAN}│{_NC}{cl}" + " " * padding + f"{_CYAN}│{_NC}")
+    lines.append(f"{_CYAN}└" + "─" * border + f"┘{_NC}")
+    return "\n".join(lines)
+
+
+def init_global_iam() -> Path:
+    """Write a starter iam.yaml to ~/.prismor/iam.yaml and return its path."""
+    path = _GLOBAL_IAM_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_STARTER_CONFIG, encoding="utf-8")
+    return path
+
+
+def init_project_iam(workspace: Path) -> Path:
+    """Write a starter iam.yaml to .prismor-warden/iam.yaml and return its path."""
+    path = workspace / ".prismor-warden" / _PROJECT_IAM_FILENAME
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_STARTER_CONFIG, encoding="utf-8")
+    return path

--- a/warden/iam.py
+++ b/warden/iam.py
@@ -7,6 +7,10 @@ Agent identities are defined in YAML config files. Config resolution order:
 The active agent identity is set via the WARDEN_AGENT_ID environment variable.
 If unset, no IAM restrictions are applied beyond the base Warden policy.
 
+Trust boundary: WARDEN_AGENT_ID is inherited by the agent being constrained, so
+IAM guards cooperative/misconfigured agents, not adversarial ones. See the
+``check_iam`` docstring for details and mitigations.
+
 Config format:
   agents:
     readonly-bot:
@@ -87,22 +91,52 @@ def _load_yaml(path: Path) -> Optional[Dict[str, Any]]:
         return None
 
 
+def _mtime(path: Path) -> float:
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return -1.0
+
+
+# path+mtime keyed memo. Per-event hook runs are separate processes so this is
+# a no-op there, but the long-lived `warden serve` path calls load_iam_config
+# on every request — this keeps it off the YAML parser in the hot path while
+# still reloading automatically when either config file changes on disk.
+_CONFIG_CACHE: Dict[Any, Dict[str, Any]] = {}
+
+
 def load_iam_config(workspace: Optional[Path] = None) -> Dict[str, Any]:
-    """Load IAM config. Project-level agents override global agents."""
+    """Load IAM config. Project-level agents override global agents.
+
+    Memoized on the (path, mtime) of both config files; a change to either
+    file invalidates the cache automatically on the next call.
+    """
+    project_path = (
+        workspace / ".prismor-warden" / _PROJECT_IAM_FILENAME if workspace else None
+    )
+    cache_key = (
+        str(_GLOBAL_IAM_PATH), _mtime(_GLOBAL_IAM_PATH),
+        str(project_path) if project_path else "",
+        _mtime(project_path) if project_path else -1.0,
+    )
+    cached = _CONFIG_CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
     config: Dict[str, Any] = {}
 
     global_cfg = _load_yaml(_GLOBAL_IAM_PATH)
     if global_cfg:
         config.update(global_cfg)
 
-    if workspace:
-        project_path = workspace / ".prismor-warden" / _PROJECT_IAM_FILENAME
+    if project_path is not None:
         project_cfg = _load_yaml(project_path)
         if project_cfg:
             project_agents = project_cfg.get("agents", {})
             if project_agents:
                 config.setdefault("agents", {}).update(project_agents)
 
+    _CONFIG_CACHE[cache_key] = config
     return config
 
 
@@ -131,6 +165,10 @@ _DENY_ALL_PROFILE: Dict[str, Any] = {
     "allowed_paths": ["**"],
 }
 
+# Agent ids we've already warned about, so the unknown-identity notice prints
+# once per process instead of on every tool call (the hook hot path).
+_WARNED_UNKNOWN_IDS: set = set()
+
 
 def check_iam(
     workspace: Optional[Path] = None,
@@ -141,6 +179,14 @@ def check_iam(
 
     Returns a finding dict if the event is blocked, None if allowed or if no
     WARDEN_AGENT_ID is set.
+
+    Trust boundary: the identity is selected by the ``WARDEN_AGENT_ID``
+    environment variable, which is inherited by the very agent being
+    constrained. An identity that can execute commands can spawn a child
+    process with the variable unset (disabling IAM) or set to a more permissive
+    profile. IAM is therefore a guardrail for cooperative/misconfigured agents,
+    not a sandbox against an adversarial one — pair it with a deny-all base
+    policy and OS-level isolation when the threat model requires it.
     """
     agent_id = get_active_agent_id()
     if not agent_id or event is None:
@@ -150,10 +196,12 @@ def check_iam(
     profile = resolve_agent_profile(agent_id, config)
 
     if profile is None:
-        sys.stderr.write(
-            f"[warden/iam] unknown agent identity '{agent_id}' — applying deny-all policy.\n"
-            f"             Add '{agent_id}' to ~/.prismor/iam.yaml or .prismor-warden/iam.yaml\n"
-        )
+        if agent_id not in _WARNED_UNKNOWN_IDS:
+            sys.stderr.write(
+                f"[warden/iam] unknown agent identity '{agent_id}' — applying deny-all policy.\n"
+                f"             Add '{agent_id}' to ~/.prismor/iam.yaml or .prismor-warden/iam.yaml\n"
+            )
+            _WARNED_UNKNOWN_IDS.add(agent_id)
         profile = _DENY_ALL_PROFILE
 
     from warden.scoped_agent import check_scoped_rules

--- a/warden/scoped_agent.py
+++ b/warden/scoped_agent.py
@@ -25,6 +25,23 @@ _EVENT_TYPE_TO_TOOL = {
     "network": "WebFetch",
 }
 
+_KNOWN_TOOLS = {"Read", "Write", "Edit", "MultiEdit", "Bash", "WebFetch", "WebSearch"}
+
+
+def _resolve_tool_name(event: Dict[str, Any]) -> Optional[str]:
+    """Resolve the concrete tool name for an event.
+
+    Prefers the original tool name carried in ``metadata.tool_name`` (set by the
+    hook normalizer) so deny_tools can target the specific tool that ran — e.g.
+    distinguishing Edit from Write within a single file_write event. Falls back
+    to the event-type mapping for synthetic events that carry no metadata (the
+    CLI ``iam check`` path and unit tests).
+    """
+    meta_tool = (event.get("metadata") or {}).get("tool_name") or ""
+    if meta_tool in _KNOWN_TOOLS:
+        return meta_tool
+    return _EVENT_TYPE_TO_TOOL.get(event.get("type", ""))
+
 
 # ── Rule synthesis ─────────────────────────────────────────────────────────
 
@@ -223,22 +240,36 @@ def check_scoped_rules(
     Returns a finding dict if the event is blocked, None if allowed.
     """
     event_type = event.get("type", "")
-    tool_name = _EVENT_TYPE_TO_TOOL.get(event_type)
+    tool_name = _resolve_tool_name(event)
 
     # Tool check
     if tool_name:
         allowed = rules.get("allowed_tools", [])
         denied = rules.get("deny_tools", [])
 
-        # Handle Write/Edit distinction: if event is file_write, check both Write and Edit
+        # deny_tools takes precedence over allowed_tools: an explicitly denied
+        # tool is blocked even when a broader allow-rule would otherwise permit
+        # it (e.g. allowed_tools:[Read,Edit] + deny_tools:[Write] blocks Write).
+        if tool_name in denied:
+            return _scoped_finding(
+                session_id,
+                f"Tool '{tool_name}' is explicitly denied for this session",
+                event_type,
+            )
+
         if event_type == "file_write":
-            if "Write" not in allowed and "Edit" not in allowed and "MultiEdit" not in allowed:
+            # A write may arrive as Write, Edit, or MultiEdit. Permit it only if
+            # the concrete tool is allowed, or — when the event carries no
+            # tool name — any write-family tool is allowed and not denied.
+            write_family = ("Write", "Edit", "MultiEdit")
+            permitted = [t for t in write_family if t in allowed and t not in denied]
+            if tool_name not in allowed and not permitted:
                 return _scoped_finding(
                     session_id,
                     f"Tool '{tool_name}' is not in scope for this session",
                     event_type,
                 )
-        elif tool_name not in allowed or tool_name in denied:
+        elif tool_name not in allowed:
             return _scoped_finding(
                 session_id,
                 f"Tool '{tool_name}' is not in scope for this session",


### PR DESCRIPTION
## Summary

- Adds `warden/iam.py` — a new IAM module that defines named agent identities (e.g. `readonly-bot`, `researcher`, `code-reviewer`) with per-identity tool, path, and network permissions loaded from `~/.prismor/iam.yaml` or `.prismor-warden/iam.yaml`
- Patches `warden/cli.py` hook-dispatch to call `check_iam()` on every event — blocks violations the same way as base policy findings
- Adds `warden iam` CLI subcommand: `list`, `init`, `show <name>`, `check <name> --type ... --value ...`

## How it works

Set `WARDEN_AGENT_ID=<name>` before launching an agent. Warden looks up the named profile and enforces it on every tool call:

```bash
warden iam init                                  # create ~/.prismor/iam.yaml
WARDEN_AGENT_ID=readonly-bot claude              # read-only agent
WARDEN_AGENT_ID=researcher claude                # web access, no writes
warden iam check readonly-bot --type write --value "src/main.py"  # BLOCK
warden iam check researcher --type network --value "https://api.example.com"  # ALLOW
```

## Test plan

- [ ] `warden iam init` creates `~/.prismor/iam.yaml` with starter profiles
- [ ] `warden iam list` lists identities; marks active one when `WARDEN_AGENT_ID` is set
- [ ] `warden iam show <name>` prints the permission box
- [ ] `warden iam check <name> --type write --value x` exits 2 (BLOCK) for `readonly-bot`
- [ ] `warden iam check <name> --type read --value x` exits 0 (ALLOW) for `readonly-bot`
- [ ] Unknown `WARDEN_AGENT_ID` falls back to deny-all policy
- [ ] Per-project `.prismor-warden/iam.yaml` overrides global config

🤖 Generated with [Claude Code](https://claude.com/claude-code)