### PR TITLE
feat(cloak): detect-and-block raw secrets at the tool boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Standard OS-level and endpoint security tools monitor the kernel and filesystem.
 - 📦 [Supply Chain](docs/supply-chain.md) covers install-time enforcement, IOC matching, and risk scoring
 - 🛜 [Network Isolation](docs/network-isolation.md) covers egress allowlists, raw IP detection, and tunnel blocking
 - 🔍 [Skill Scanner](docs/skill-scanner.md) covers MCP server and skill risk scanning across supported agents
-- 🔐 [Sweep and Cloak](docs/sweep-and-cloak.md) covers secret prevention at tool boundaries and cleanup for leaked secrets
+- 🔐 [Sweep and Cloak](docs/sweep-and-cloak.md) covers secret prevention at tool boundaries and cleanup for leaked secrets — see [Using Cloak](docs/using-cloak.md) for the practical setup, best practices, and threat model
 - 🐳 [Docker and Containers](docs/docker.md) covers container hardening, prerequisites, and known limitations
 
 These capabilities map to the [OWASP Top 10 for LLM Applications](https://genai.owasp.org/llm-top-10/) — covering prompt injection (LLM01), sensitive information disclosure (LLM02), supply chain (LLM03), improper output handling (LLM05), and excessive agency (LLM06).

--- a/docs/using-cloak.md
+++ b/docs/using-cloak.md
@@ -1,0 +1,85 @@
+# Using Cloak — secret protection in practice
+
+Cloak keeps real secret values out of the model's context, the transcript, and
+the upstream API. You work with placeholders (`@@SECRET:name@@`); the real value
+only exists inside the local hook process at execution time.
+
+This is the practical guide. For internals see
+[`warden/cloaking/README.md`](../warden/cloaking/README.md).
+
+## Setup (once)
+
+Two layers. Install both — they're complementary:
+
+```bash
+warden cloak install                                  # prevention: cloak secrets at the tool boundary
+warden install-hooks --agent claude --mode enforce    # enforcement: block direct reads of the vault
+```
+
+Cloak alone keeps secrets out of context. The runtime monitor is what stops an
+agent from simply opening the vault files (see *Threat model* below) — so you
+want both.
+
+## Everyday use
+
+You mostly do nothing. The flow is automatic:
+
+- **Paste a secret into chat** → it's detected, vaulted, and your prompt is
+  blocked once so you resubmit the sanitized version. From then on the model
+  sees only `@@SECRET:auto_xxxx@@`.
+- **The model emits a raw secret in a command, file, or MCP call** → the call is
+  denied, the value is vaulted, and the model is told to use the placeholder.
+- **The model uses a placeholder** → the hook substitutes the real value at run
+  time and scrubs it back out of the output.
+
+Register a secret deliberately (value read from stdin, never argv):
+
+```bash
+warden cloak add stripe_key      # then reference it anywhere as @@SECRET:stripe_key@@
+warden cloak list                # placeholder names only — never values
+```
+
+## Custom detection patterns
+
+Built-in patterns cover Stripe, GitHub, AWS, Google, Slack, GitLab, and JWTs.
+Add your org's token formats:
+
+```bash
+warden cloak pattern add 'mycorp_[0-9a-f]{32}'
+```
+
+Patterns are POSIX regex, validated on add, and apply to both the paste guard
+and the tool-call guard.
+
+## Best practices
+
+- **Run both layers.** `cloak install` without the enforce-mode monitor leaves
+  the vault readable by a determined or prompt-injected agent.
+- **Reference, never inline.** Use `@@SECRET:name@@` in commands and files. Don't
+  ask the model to hardcode a live secret into a file — store the placeholder or
+  an env-var reference instead.
+- **Protect the vault directory.** `~/.prismor/secrets/` is plaintext on disk
+  (file permissions are its only guard). Exclude it from git, backups, and sync
+  (Time Machine, iCloud, Dropbox). Add a Claude `permissions.deny` rule for
+  `Read(~/.prismor/secrets/**)` for defense in depth.
+- **`/clear` after any suspected leak.** If the model ever saw a raw value, it
+  can still echo it from memory — hooks can't filter assistant prose.
+- **Don't fight a false positive — bypass it.** Prefix a prompt with `!!allow `
+  to discuss a secret format without auto-cloaking.
+
+## Threat model — what it does and doesn't cover
+
+| Scenario | Covered? |
+|---|---|
+| Secret in a pasted prompt | ✅ auto-vaulted, prompt re-sanitized |
+| Raw secret in a command / file write / MCP arg | ✅ denied + vaulted |
+| Model using a placeholder | ✅ resolved locally, output scrubbed |
+| Agent directly reading a vault file | ✅ **only with the enforce-mode monitor** |
+| Secret with no recognizable shape (hand-typed, freshly generated) | ⚠️ may not match a pattern |
+| Model narrating a value it already saw | ❌ use `/clear` |
+| Anything running as your user, off-agent | ❌ OS file permissions only |
+
+Bottom line: in normal placeholder-based use with both layers installed, the AI
+never sees vault contents. The vault is not encrypted at rest, so the protection
+against a *direct read* is the runtime monitor and your file permissions — not
+the cloaking hooks alone.

--- a/tests/test_cloak_secret_guard.py
+++ b/tests/test_cloak_secret_guard.py
@@ -1,0 +1,154 @@
+"""Tests for the cloaking detect-and-block secret guard.
+
+Covers two layers:
+
+  A. patterns.py        — built-in + custom pattern management
+  B. secret-guard.sh    — PreToolUse detect + vault + deny hook (end-to-end)
+
+Each test runs against an isolated $PRISMOR_HOME so the developer's real vault
+is never touched. Run:  python3 tests/test_cloak_secret_guard.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Allow running as a plain script from the repo root.
+_REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO))
+
+# Isolate the vault / pattern file before importing the module under test.
+_HOME = Path(tempfile.mkdtemp(prefix="prismor-test-"))
+os.environ["PRISMOR_HOME"] = str(_HOME)
+os.environ["PRISMOR_SECRETS_DIR"] = str(_HOME / "secrets")
+os.environ["PRISMOR_CLOAK_PATTERNS"] = str(_HOME / "cloak_patterns.txt")
+
+from warden.cloaking import patterns  # noqa: E402
+
+_GUARD = _REPO / "warden" / "cloaking" / "hooks" / "secret-guard.sh"
+
+_passed = 0
+_failed = 0
+
+
+def check(name: str, ok: bool, detail: str = "") -> None:
+    global _passed, _failed
+    if ok:
+        _passed += 1
+        print(f"  PASS  {name}")
+    else:
+        _failed += 1
+        print(f"  FAIL  {name}  {detail}")
+
+
+def run_guard(payload: dict) -> dict | None:
+    """Invoke secret-guard.sh with a tool payload; return parsed JSON or None."""
+    proc = subprocess.run(
+        ["bash", str(_GUARD)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=os.environ,
+    )
+    out = proc.stdout.strip()
+    return json.loads(out) if out else None
+
+
+# ── A. patterns.py ───────────────────────────────────────────────────────────
+print("\n[A] pattern management")
+
+builtins = patterns.builtin_patterns()
+check("ships >= 14 built-in patterns", len(builtins) >= 14, len(builtins))
+check("AKIA built-in present", "AKIA[0-9A-Z]{16}" in builtins)
+check("custom list starts empty", patterns.list_custom_patterns() == [])
+
+added = patterns.add_pattern("mycorp_[0-9a-f]{32}")
+check("add_pattern returns True for new pattern", added is True)
+check("custom pattern now listed", "mycorp_[0-9a-f]{32}" in patterns.list_custom_patterns())
+check("all_patterns includes built-in + custom",
+      "mycorp_[0-9a-f]{32}" in patterns.all_patterns() and "AKIA[0-9A-Z]{16}" in patterns.all_patterns())
+
+dup = patterns.add_pattern("mycorp_[0-9a-f]{32}")
+check("adding a duplicate returns False", dup is False)
+check("duplicate not written twice",
+      patterns.list_custom_patterns().count("mycorp_[0-9a-f]{32}") == 1)
+
+try:
+    patterns.add_pattern("bad([regex")
+    check("invalid regex raises ValueError", False, "no exception")
+except ValueError:
+    check("invalid regex raises ValueError", True)
+
+try:
+    patterns.remove_pattern("AKIA[0-9A-Z]{16}")
+    check("removing a built-in raises ValueError", False, "no exception")
+except ValueError:
+    check("removing a built-in raises ValueError", True)
+
+removed = patterns.remove_pattern("mycorp_[0-9a-f]{32}")
+check("remove_pattern returns True", removed is True)
+check("custom list empty after removal", patterns.list_custom_patterns() == [])
+check("removing a missing pattern returns False",
+      patterns.remove_pattern("nope_[0-9]{9}") is False)
+
+
+# ── B. secret-guard.sh end-to-end ────────────────────────────────────────────
+print("\n[B] secret-guard hook")
+
+# 1. Raw secret in a Bash command → deny + vault.
+res = run_guard({"tool_name": "Bash",
+                 "tool_input": {"command": "deploy --key sk_live_abcd1234efgh5678ijkl"}})
+decision = (res or {}).get("hookSpecificOutput", {}).get("permissionDecision")
+check("raw secret in Bash is denied", decision == "deny", res)
+reason = (res or {}).get("hookSpecificOutput", {}).get("permissionDecisionReason", "")
+check("deny reason references a placeholder, never the raw value",
+      "@@SECRET:auto_" in reason and "sk_live_abcd1234efgh5678ijkl" not in reason)
+vaulted = list((_HOME / "secrets").glob("auto_*"))
+check("secret was written to the vault", len(vaulted) == 1, vaulted)
+
+# 2. Same secret again (now vaulted) → allowed (no-op).
+res2 = run_guard({"tool_name": "Bash",
+                  "tool_input": {"command": "deploy --key sk_live_abcd1234efgh5678ijkl"}})
+check("already-vaulted value is allowed through (idempotent)", res2 is None, res2)
+
+# 3. Placeholder reference → allowed.
+res3 = run_guard({"tool_name": "Bash",
+                  "tool_input": {"command": "deploy --key @@SECRET:stripe@@"}})
+check("placeholder reference is allowed", res3 is None, res3)
+
+# 4. Secret in a Write file body → deny with file-specific guidance.
+res4 = run_guard({"tool_name": "Write",
+                  "tool_input": {"file_path": "/tmp/x.env", "content": "AWS=AKIAIOSFODNN7EXAMPLE"}})
+d4 = (res4 or {}).get("hookSpecificOutput", {})
+check("secret in Write body is denied", d4.get("permissionDecision") == "deny", res4)
+check("Write guidance says not to write the literal secret",
+      "Do NOT write the literal secret" in d4.get("permissionDecisionReason", ""))
+
+# 5. Secret in MCP tool args → deny.
+res5 = run_guard({"tool_name": "mcp__github__create",
+                  "tool_input": {"token": "ghp_1234567890abcdefghij1234567890abcdef"}})
+check("secret in MCP args is denied",
+      (res5 or {}).get("hookSpecificOutput", {}).get("permissionDecision") == "deny", res5)
+
+# 6. Non-scanned tool (Read) → allowed even if input looks secret-ish.
+res6 = run_guard({"tool_name": "Read", "tool_input": {"file_path": "AKIAIOSFODNN7EXAMPLE"}})
+check("non-scanned tool is not inspected", res6 is None, res6)
+
+# 7. Custom pattern is honored by the hook.
+patterns.add_pattern("mycorp_[0-9a-f]{32}")
+res7 = run_guard({"tool_name": "Bash",
+                  "tool_input": {"command": "login mycorp_0123456789abcdef0123456789abcdef"}})
+check("custom pattern triggers the guard",
+      (res7 or {}).get("hookSpecificOutput", {}).get("permissionDecision") == "deny", res7)
+
+
+# ── summary ──────────────────────────────────────────────────────────────────
+import shutil  # noqa: E402
+shutil.rmtree(_HOME, ignore_errors=True)
+
+print(f"\n{_passed} passed, {_failed} failed")
+sys.exit(1 if _failed else 0)

--- a/warden/cli.py
+++ b/warden/cli.py
@@ -28,6 +28,7 @@ Commands:
   cloak list      List registered placeholder names (never values)
   cloak remove NAME  Delete a registered secret
   cloak status    Show whether cloaking hooks are installed
+  cloak pattern   Manage secret-detection regexes (list/add/remove)
 """
 from __future__ import annotations
 
@@ -819,6 +820,7 @@ def main() -> None:
                 workspace=workspace,
                 scope=args.scope,
                 enable_userprompt_guard=not args.no_userprompt_guard,
+                enable_secret_guard=not args.no_secret_guard,
                 enable_sweep_on_stop=args.sweep_on_stop,
             )
             print(f"Installed cloaking hooks at {result['configPath']}")
@@ -902,7 +904,62 @@ def main() -> None:
                 print(f"No secret named {args.name!r}")
             return
 
-        raise SystemExit("Usage: warden cloak {install|uninstall|add|list|remove|status}")
+        if sub == "pattern":
+            from warden.cloaking import (
+                add_pattern,
+                builtin_patterns,
+                custom_patterns_file,
+                list_custom_patterns,
+                remove_pattern,
+            )
+
+            psub = getattr(args, "pattern_command", None)
+
+            if psub == "add":
+                try:
+                    added = add_pattern(args.regex)
+                except ValueError as exc:
+                    sys.stderr.write(f"error: {exc}\n")
+                    raise SystemExit(1)
+                if added:
+                    print(f"Added custom pattern: {args.regex}")
+                    print(f"  stored in {custom_patterns_file()}")
+                else:
+                    print(f"Pattern already present (built-in or custom): {args.regex}")
+                return
+
+            if psub == "remove":
+                try:
+                    removed = remove_pattern(args.regex)
+                except ValueError as exc:
+                    sys.stderr.write(f"error: {exc}\n")
+                    raise SystemExit(1)
+                print(
+                    f"Removed custom pattern: {args.regex}" if removed
+                    else f"No custom pattern matching: {args.regex}"
+                )
+                return
+
+            # Default / "list": show built-ins and custom patterns.
+            builtins = builtin_patterns()
+            custom = list_custom_patterns()
+            print(f"  {_color('BUILT-IN PATTERNS', _BOLD)} ({len(builtins)})")
+            print(f"  {_color('─' * 50, _DIM)}")
+            for p in builtins:
+                print(f"  {_color('•', _DIM)} {p}")
+            print()
+            label = _color("CUSTOM PATTERNS", _BOLD)
+            print(f"  {label} ({len(custom)})  {_color(str(custom_patterns_file()), _DIM)}")
+            print(f"  {_color('─' * 50, _DIM)}")
+            if custom:
+                for p in custom:
+                    print(f"  {_color('•', _CYAN)} {p}")
+            else:
+                print(f"  {_color('none — add with: warden cloak pattern add <regex>', _DIM)}")
+            print()
+            return
+
+        raise SystemExit("Usage: warden cloak {install|uninstall|add|list|remove|status|pattern}")
 
     # ── canary subcommands ─────────────────────────────────────────────
     if args.command == "canary":
@@ -1286,6 +1343,8 @@ def build_parser() -> argparse.ArgumentParser:
                            help="Hook scope (default: project)")
     t_install.add_argument("--no-userprompt-guard", action="store_true",
                            help="Skip the UserPromptSubmit soft-block hook (use a clipboard filter instead)")
+    t_install.add_argument("--no-secret-guard", action="store_true",
+                           help="Skip the PreToolUse detect-and-block hook for raw secrets in tool calls")
     t_install.add_argument("--sweep-on-stop", action="store_true",
                            help="Also wire a Stop-hook dry-run sweep for residue detection")
 
@@ -1308,6 +1367,15 @@ def build_parser() -> argparse.ArgumentParser:
     t_status.add_argument("--workspace", help="Workspace path")
     t_status.add_argument("--scope", choices=["project", "user"], default="project",
                           help="Hook scope (default: project)")
+
+    t_pattern = cloak_sub.add_parser(
+        "pattern", help="Manage secret-detection regexes (built-in + custom)")
+    pattern_sub = t_pattern.add_subparsers(dest="pattern_command")
+    pattern_sub.add_parser("list", help="List built-in and custom patterns (default)")
+    p_add = pattern_sub.add_parser("add", help="Add a custom detection regex (POSIX ERE)")
+    p_add.add_argument("regex", help="Regex to detect, e.g. 'mycorp_[0-9a-f]{32}'")
+    p_remove = pattern_sub.add_parser("remove", help="Remove a custom detection regex")
+    p_remove.add_argument("regex", help="Exact custom regex to remove")
 
     # ── canary ─────────────────────────────────────────────────────────
     canary_parser = subparsers.add_parser(

--- a/warden/cloaking/README.md
+++ b/warden/cloaking/README.md
@@ -51,16 +51,22 @@ This merges four hook entries into `.claude/settings.json` (preserving any Warde
 
 | Event | Matcher | Script | Purpose |
 |---|---|---|---|
+| `PreToolUse` | `Bash\|Write\|Edit\|MultiEdit\|mcp__.*` | `secret-guard.sh` | Detect raw secrets in tool input, vault + deny |
 | `PreToolUse` | `Bash` | `decloak.sh` | Substitute placeholders, wrap with `sed` |
 | `PostToolUse` | `mcp__.*` | `recloak-mcp.sh` | Scrub real values from MCP responses |
 | `UserPromptSubmit` | — | `userprompt-guard.sh` | Soft-block + auto-cloak pasted secrets |
 | `Stop` (opt) | — | `sweep-on-stop.sh` | Dry-run sweep for residue (off by default) |
+
+`secret-guard.sh` is registered *before* `decloak.sh` so it scans the model's
+original input; it is also order-independent because it skips any value already
+present in the vault (see below).
 
 Flags:
 
 ```bash
 warden cloak install --scope user           # install globally in ~/.claude
 warden cloak install --no-userprompt-guard  # skip the paste-detection hook
+warden cloak install --no-secret-guard      # skip the tool-call detect-and-block hook
 warden cloak install --sweep-on-stop        # add the Stop-hook sweep
 ```
 
@@ -108,12 +114,75 @@ The UX cost is one re-paste per leaked prompt. The original prompt was *not* tra
 
 ---
 
+## The tool-call boundary (detect-and-block)
+
+`userprompt-guard.sh` only covers what *you* paste. But the model can introduce
+a raw secret on its own — by generating one, reading it out of a file, or
+copying a value from earlier output into a command, a file write, or an MCP
+argument. `secret-guard.sh` (a `PreToolUse` hook) closes that gap.
+
+When the model emits a tool call whose input matches a secret pattern, the hook:
+
+1. **Vaults** the raw value under a deterministic `auto_<hash>` name — *unless
+   that exact value is already in the vault* (so a value `decloak.sh` just
+   substituted, or any manually-registered secret, is recognized as legitimate
+   and passes through untouched).
+2. **Denies** the call with a reason that names the `@@SECRET:auto_xxxx@@`
+   placeholder to use instead — and never echoes the raw value.
+
+The raw secret therefore never executes, is never written to a file, and never
+reaches the transcript or the upstream API. The model sees the deny reason and
+retries with the placeholder, which `decloak.sh` resolves for `Bash`. For
+`Write`/`Edit`/MCP the placeholder (or an env-var reference) is what gets
+stored — you should not be hardcoding live secrets into files anyway.
+
+```
+model emits raw  sk_live_…  in a Bash command
+        │
+        ▼
+  secret-guard.sh  ── value already in vault?  ── yes ─► allow (no-op)
+        │ no
+        ▼
+  vault as auto_<hash>  +  DENY("use @@SECRET:auto_<hash>@@ instead")
+        │
+        ▼
+  model retries with the placeholder ──► decloak.sh substitutes & runs
+```
+
+Because of the vault check, install order between `secret-guard.sh` and
+`decloak.sh` does not matter and retries are idempotent.
+
+---
+
+## Configurable detection patterns
+
+Both guards detect secrets from a shared, file-based pattern set:
+
+* **Built-in** — `builtin_patterns.txt` (shipped in this module): conservative,
+  known-prefix credential formats (Stripe, GitHub, AWS, Google, Slack, GitLab,
+  JWT). This is the single source of truth shared by the bash hooks and the
+  Python CLI — no duplicated regex.
+* **Custom** — `$PRISMOR_HOME/cloak_patterns.txt` (override with
+  `$PRISMOR_CLOAK_PATTERNS`): your org-specific token formats.
+
+Manage custom patterns — one POSIX ERE per line — with:
+
+```bash
+warden cloak pattern list                       # show built-in + custom patterns
+warden cloak pattern add 'mycorp_[0-9a-f]{32}'  # validated, appended to custom file
+warden cloak pattern remove 'mycorp_[0-9a-f]{32}'
+```
+
+`add` rejects an uncompilable regex; built-in patterns cannot be removed.
+
+---
+
 ## What this does *not* protect
 
 Enumerated honestly so you know what to layer on top:
 
 1. **Hand-typed secrets shorter than ~16 chars.** No prefix, too short for entropy heuristics, indistinguishable from benign text.
-2. **Secrets generated mid-turn** (`openssl rand`, `aws iam create-access-key`, `ssh-keygen`). The sed-wrap scrubber only knows about values already in `$PRISMOR_SECRETS_DIR`; a freshly minted value flows through unscrubbed.
+2. **Secrets generated mid-turn** (`openssl rand`, `aws iam create-access-key`, `ssh-keygen`). The `sed`-wrap scrubber only knows about values already in `$PRISMOR_SECRETS_DIR`, so a freshly minted value flows through the *generating* command's output unscrubbed. `secret-guard.sh` does catch it on the *next* tool call if the value matches a known pattern (e.g. a generated `AKIA…` reused in a later command) — but a value with no recognizable shape still slips through.
 3. **The secrets directory itself**, if committed, synced, or backed up without exclusion. Treat it as a single point of failure.
 4. **Built-in `Read` of secret-bearing files.** `PostToolUse` can only rewrite MCP tool output, not built-in Read. Add a `permissions.deny` rule under `Read(./secrets/**)` in your Claude settings to close this gap, and route secret access through the placeholder syntax instead.
 5. **Assistant-side narration.** If the model already saw a real value (through paste, Read, or a command that bypassed the wrapper), it can echo the value in prose. Hooks cannot filter assistant text. Use `/clear` immediately after any suspected leak.
@@ -151,8 +220,12 @@ warden/cloaking/
 ├── __init__.py             # public API re-exports
 ├── installer.py            # install/uninstall settings.json merger
 ├── secrets_store.py        # add/list/remove operations on $PRISMOR_SECRETS_DIR
+├── patterns.py             # built-in + custom detection-pattern management
+├── builtin_patterns.txt    # single source of truth for detection regexes
 ├── hooks/
-│   ├── decloak.sh          # PreToolUse:Bash
+│   ├── _patterns.sh        # shared bash loader (sourced by the guards)
+│   ├── decloak.sh          # PreToolUse:Bash — placeholder substitution
+│   ├── secret-guard.sh     # PreToolUse — detect raw secrets, vault + deny
 │   ├── recloak-mcp.sh      # PostToolUse:mcp__.*
 │   ├── userprompt-guard.sh # UserPromptSubmit soft-block
 │   └── sweep-on-stop.sh    # Stop (opt-in)

--- a/warden/cloaking/__init__.py
+++ b/warden/cloaking/__init__.py
@@ -12,10 +12,20 @@ Public entry points (imported by ``warden/cli.py``):
   list_secrets   — list registered placeholder names (never values)
   remove_secret  — delete a registered secret
   secrets_dir    — path to the secrets directory (honors $PRISMOR_SECRETS_DIR)
+  add_pattern / remove_pattern / list_custom_patterns / builtin_patterns
+                 — manage the secret-detection regexes used by the guard hooks
 """
 from __future__ import annotations
 
 from warden.cloaking.installer import install, uninstall, status
+from warden.cloaking.patterns import (
+    add_pattern,
+    all_patterns,
+    builtin_patterns,
+    custom_patterns_file,
+    list_custom_patterns,
+    remove_pattern,
+)
 from warden.cloaking.secrets_store import (
     add_secret,
     list_secrets,
@@ -31,4 +41,10 @@ __all__ = [
     "list_secrets",
     "remove_secret",
     "secrets_dir",
+    "add_pattern",
+    "remove_pattern",
+    "list_custom_patterns",
+    "builtin_patterns",
+    "all_patterns",
+    "custom_patterns_file",
 ]

--- a/warden/cloaking/builtin_patterns.txt
+++ b/warden/cloaking/builtin_patterns.txt
@@ -1,0 +1,31 @@
+# Prismor Warden cloaking — built-in secret detection patterns.
+#
+# One POSIX ERE per line (the form accepted by `grep -oE`). Blank lines and
+# lines beginning with `#` are ignored. This file is the SINGLE SOURCE OF
+# TRUTH for the patterns used by every cloaking component:
+#
+#   * hooks/_patterns.sh   (bash loader, sourced by the PreToolUse/UserPrompt hooks)
+#   * patterns.py          (Python loader, used by `warden cloak pattern …`)
+#
+# Patterns are conservative and known-prefix only: they target credential
+# formats with a recognizable, high-entropy shape so that benign prose does
+# not trip them. Add org-specific patterns through your user config file
+# (`warden cloak pattern add '<regex>'`) rather than editing this file.
+#
+# Order matters: longest / most-specific first, so a partial match does not
+# fire for the wrong pattern.
+
+sk_live_[0-9a-zA-Z]{16,}
+sk_test_[0-9a-zA-Z]{16,}
+rk_live_[0-9a-zA-Z]{16,}
+github_pat_[0-9a-zA-Z_]{20,}
+ghp_[0-9a-zA-Z]{36}
+gho_[0-9a-zA-Z]{36}
+ghs_[0-9a-zA-Z]{36}
+ghu_[0-9a-zA-Z]{36}
+AKIA[0-9A-Z]{16}
+ASIA[0-9A-Z]{16}
+AIza[0-9A-Za-z_-]{35}
+xox[bpoar]-[0-9]+-[0-9]+-[0-9a-zA-Z]{24,}
+glpat-[0-9a-zA-Z_-]{20,}
+eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+

--- a/warden/cloaking/hooks/_patterns.sh
+++ b/warden/cloaking/hooks/_patterns.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Prismor Warden — shared cloaking helpers, sourced by the hook scripts.
+#
+# Provides:
+#   prismor_load_patterns       Populate the global PATTERNS array from the
+#                               built-in pattern file plus the user's custom
+#                               pattern file (if any).
+#   prismor_value_is_cloaked    Return 0 if a value already exists verbatim in
+#                               the secrets vault (so legitimately decloaked
+#                               values are never re-flagged).
+#
+# Pure bash, no external deps beyond coreutils. Sourced — does not run on its
+# own. Callers must have `set -uo pipefail` already in effect.
+
+# Resolve this file's directory so we can find builtin_patterns.txt regardless
+# of the caller's CWD.
+_PRISMOR_HOOKS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_PRISMOR_BUILTIN_PATTERNS="$_PRISMOR_HOOKS_DIR/../builtin_patterns.txt"
+
+# Where custom (org-specific) patterns live. Overridable for testing.
+prismor_custom_patterns_file() {
+  if [[ -n "${PRISMOR_CLOAK_PATTERNS:-}" ]]; then
+    printf '%s' "$PRISMOR_CLOAK_PATTERNS"
+  else
+    printf '%s' "${PRISMOR_HOME:-$HOME/.prismor}/cloak_patterns.txt"
+  fi
+}
+
+prismor_secrets_dir() {
+  if [[ -n "${PRISMOR_SECRETS_DIR:-}" ]]; then
+    printf '%s' "$PRISMOR_SECRETS_DIR"
+  else
+    printf '%s' "${PRISMOR_HOME:-$HOME/.prismor}/secrets"
+  fi
+}
+
+# Populate the global `PATTERNS` array. Built-ins first (most specific),
+# then user patterns appended. Comment (`#`) and blank lines are skipped.
+prismor_load_patterns() {
+  PATTERNS=()
+  local file line
+  for file in "$_PRISMOR_BUILTIN_PATTERNS" "$(prismor_custom_patterns_file)"; do
+    [[ -f "$file" ]] || continue
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      # Strip nothing — patterns may contain leading spaces only if intended;
+      # but skip blank and comment lines.
+      [[ -z "${line//[[:space:]]/}" ]] && continue
+      [[ "${line#"${line%%[![:space:]]*}"}" == \#* ]] && continue
+      PATTERNS+=("$line")
+    done < "$file"
+  done
+}
+
+# prismor_value_is_cloaked <value>
+# Returns 0 if any file in the secrets vault contains exactly <value>.
+# Used so that a value decloak.sh just substituted in (placeholder -> real),
+# or any manually-registered secret, is recognized as already-cloaked and is
+# NOT treated as a fresh leak.
+prismor_value_is_cloaked() {
+  local value="$1" dir f
+  dir="$(prismor_secrets_dir)"
+  [[ -d "$dir" ]] || return 1
+  for f in "$dir"/*; do
+    [[ -f "$f" ]] || continue
+    if [[ "$(cat "$f")" == "$value" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}

--- a/warden/cloaking/hooks/secret-guard.sh
+++ b/warden/cloaking/hooks/secret-guard.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Prismor Warden — cloaking PreToolUse hook (detect + vault + deny).
+#
+# Complements decloak.sh. Where decloak SUBSTITUTES an existing
+# `@@SECRET:name@@` placeholder, this hook catches RAW secrets that the model
+# emitted directly — a freshly generated key, a value read from a file, or a
+# credential the model copied into a command/file/MCP arg. On a match it:
+#
+#   1. Vaults the raw value under a deterministic `auto_<hash>` name (only if
+#      it is not already in the vault).
+#   2. DENIES the tool call with a reason that names the placeholder to use
+#      instead — so the raw value never reaches the JSONL transcript or the
+#      upstream API, and the model can immediately retry with the placeholder.
+#
+# Already-cloaked values (anything present verbatim in the vault — including a
+# value decloak.sh just substituted, or a manually-registered secret) are
+# recognized and allowed. That makes this hook order-independent relative to
+# decloak.sh and idempotent across retries.
+#
+# Scanned tools: Bash (.command), Write / Edit / MultiEdit / mcp__* (full
+# tool_input). Configure detection patterns with `warden cloak pattern add`.
+#
+# Stdin:  Claude Code PreToolUse JSON payload
+# Stdout: JSON permissionDecision=deny (on a fresh raw secret), else empty.
+set -uo pipefail
+
+# shellcheck source=_patterns.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_patterns.sh"
+
+SECRETS_DIR="$(prismor_secrets_dir)"
+mkdir -p "$SECRETS_DIR"
+chmod 700 "$SECRETS_DIR" 2>/dev/null || true
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+input="$(cat)"
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+[[ -n "$tool_name" ]] || exit 0
+
+# Pick the text to scan. For Bash we scan only the command; for file-writing
+# and MCP tools we scan the entire input object so we cover content,
+# new_string, edits[], and arbitrary MCP arg names without per-tool knowledge.
+case "$tool_name" in
+  Bash)
+    scan_text="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+    kind="bash"
+    ;;
+  Write|Edit|MultiEdit)
+    scan_text="$(printf '%s' "$input" | jq -r '.tool_input // empty | tostring')"
+    kind="file"
+    ;;
+  mcp__*)
+    scan_text="$(printf '%s' "$input" | jq -r '.tool_input // empty | tostring')"
+    kind="mcp"
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+[[ -n "$scan_text" ]] || exit 0
+
+prismor_load_patterns
+[[ "${#PATTERNS[@]}" -gt 0 ]] || exit 0
+
+# Collect unique matches across all patterns.
+matches="$(
+  for pat in "${PATTERNS[@]}"; do
+    printf '%s' "$scan_text" | grep -oE "$pat" || true
+  done | awk 'NF && !seen[$0]++'
+)"
+[[ -n "$matches" ]] || exit 0
+
+# Vault each NEW (uncloaked) match; collect placeholders to report.
+reported=""
+new_count=0
+while IFS= read -r real_value; do
+  [[ -z "$real_value" ]] && continue
+
+  # Already in the vault (e.g. decloak just substituted it, or it was
+  # registered manually) → legitimate use, do not flag.
+  if prismor_value_is_cloaked "$real_value"; then
+    continue
+  fi
+
+  hash="$(printf '%s' "$real_value" | shasum -a 256 | awk '{print $1}' | cut -c1-8)"
+  placeholder_name="auto_${hash}"
+  secret_file="$SECRETS_DIR/$placeholder_name"
+  if [[ ! -f "$secret_file" ]]; then
+    printf '%s' "$real_value" > "$secret_file"
+    chmod 600 "$secret_file" 2>/dev/null || true
+  fi
+  reported+="  • @@SECRET:${placeholder_name}@@"$'\n'
+  new_count=$((new_count + 1))
+done <<< "$matches"
+
+# Every match was already cloaked → allow the call through untouched.
+[[ "$new_count" -gt 0 ]] || exit 0
+
+case "$kind" in
+  bash) usage="Re-issue this command using the placeholder(s) below — decloak.sh resolves them to the real value at execution time and scrubs the value back out of the captured output." ;;
+  file) usage="Do NOT write the literal secret to a file. Use the placeholder(s) below (or an environment-variable reference) in the file content instead." ;;
+  mcp)  usage="Re-issue this tool call using the placeholder(s) below instead of the raw value." ;;
+esac
+
+reason="Prismor cloaking: detected and vaulted ${new_count} raw secret(s) in this ${tool_name} call.
+
+The raw value was NOT executed, written, or sent to the model/API. It is now
+stored under ${SECRETS_DIR} and addressable as:
+${reported%$'\n'}
+
+${usage}"
+
+jq -n --arg r "$reason" \
+  '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'

--- a/warden/cloaking/hooks/userprompt-guard.sh
+++ b/warden/cloaking/hooks/userprompt-guard.sh
@@ -17,7 +17,10 @@
 #         or empty (no-op) otherwise.
 set -uo pipefail
 
-SECRETS_DIR="${PRISMOR_SECRETS_DIR:-$HOME/.prismor/secrets}"
+# shellcheck source=_patterns.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_patterns.sh"
+
+SECRETS_DIR="$(prismor_secrets_dir)"
 mkdir -p "$SECRETS_DIR"
 chmod 700 "$SECRETS_DIR" 2>/dev/null || true
 
@@ -36,24 +39,10 @@ if [[ "$trimmed" == "!!allow "* ]]; then
 fi
 
 # ── Detection patterns ────────────────────────────────────────────────────
-# Conservative, known-prefix only. Order matters — longest/most-specific
-# first so partial matches don't fire for the wrong pattern.
-PATTERNS=(
-  'sk_live_[0-9a-zA-Z]{16,}'          # Stripe live
-  'sk_test_[0-9a-zA-Z]{16,}'          # Stripe test
-  'rk_live_[0-9a-zA-Z]{16,}'          # Stripe restricted
-  'github_pat_[0-9a-zA-Z_]{20,}'      # GitHub fine-grained PAT
-  'ghp_[0-9a-zA-Z]{36}'               # GitHub PAT
-  'gho_[0-9a-zA-Z]{36}'               # GitHub OAuth
-  'ghs_[0-9a-zA-Z]{36}'               # GitHub server
-  'ghu_[0-9a-zA-Z]{36}'               # GitHub user-to-server
-  'AKIA[0-9A-Z]{16}'                  # AWS access key ID
-  'ASIA[0-9A-Z]{16}'                  # AWS temp access key
-  'AIza[0-9A-Za-z_-]{35}'             # Google API key
-  'xox[bpoar]-[0-9]+-[0-9]+-[0-9a-zA-Z]{24,}'  # Slack tokens
-  'glpat-[0-9a-zA-Z_-]{20,}'          # GitLab PAT
-  'eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+'  # JWT
-)
+# Loaded from the shared single-source-of-truth file (builtin_patterns.txt)
+# plus any org-specific patterns the user added via `warden cloak pattern add`.
+prismor_load_patterns
+[[ "${#PATTERNS[@]}" -gt 0 ]] || exit 0
 
 # Collect unique matches across all patterns.
 matches="$(

--- a/warden/cloaking/installer.py
+++ b/warden/cloaking/installer.py
@@ -23,9 +23,15 @@ from warden.cloaking.secrets_store import secrets_dir
 _HOOKS_SUBDIR = Path(__file__).resolve().parent / "hooks"
 
 _DECLOAK = _HOOKS_SUBDIR / "decloak.sh"
+_SECRET_GUARD = _HOOKS_SUBDIR / "secret-guard.sh"
 _RECLOAK_MCP = _HOOKS_SUBDIR / "recloak-mcp.sh"
 _USERPROMPT_GUARD = _HOOKS_SUBDIR / "userprompt-guard.sh"
 _SWEEP_ON_STOP = _HOOKS_SUBDIR / "sweep-on-stop.sh"
+
+# Tools the detect-and-block guard scans for raw secrets. Bash is covered so
+# raw secrets in shell commands are caught; the guard is order-independent vs
+# decloak because it skips any value already present in the vault.
+_SECRET_GUARD_MATCHER = "Bash|Write|Edit|MultiEdit|mcp__.*"
 
 # All cloaking hook commands share this marker so uninstall can find them.
 _MARKER = "warden/cloaking/hooks/"
@@ -102,6 +108,7 @@ def install(
     workspace: Path,
     scope: str = "project",
     enable_userprompt_guard: bool = True,
+    enable_secret_guard: bool = True,
     enable_sweep_on_stop: bool = False,
 ) -> Dict[str, Any]:
     """Install the cloaking hooks into ``settings.json``.
@@ -112,6 +119,9 @@ def install(
             ``'user'`` writes to ``~/.claude/settings.json``.
         enable_userprompt_guard: Wire the soft-block UserPromptSubmit hook.
             Disable if you plan to use a clipboard-level filter instead.
+        enable_secret_guard: Wire the PreToolUse detect-and-block hook that
+            catches raw secrets the model emits directly (not via a
+            placeholder) and denies the call after vaulting the value.
         enable_sweep_on_stop: Wire the Stop-hook dry-run sweep. Off by
             default because it runs ``warden sweep`` against ``~/.claude``
             on every session end, which is noisy for quick sessions.
@@ -134,6 +144,16 @@ def install(
     hooks = dict(config.get("hooks", {}))
 
     installed: List[str] = []
+
+    # PreToolUse: detect-and-block raw secrets. Registered BEFORE decloak so
+    # it scans the model's original input; it is also order-independent because
+    # it skips any value already present in the vault.
+    if enable_secret_guard:
+        hooks["PreToolUse"] = _merge_claude_entries(
+            hooks.get("PreToolUse", []),
+            {"matcher": _SECRET_GUARD_MATCHER, "hooks": [_hook_entry(_SECRET_GUARD)]},
+        )
+        installed.append(f"PreToolUse:{_SECRET_GUARD_MATCHER} (secret-guard)")
 
     # PreToolUse: decloak on Bash matcher.
     hooks["PreToolUse"] = _merge_claude_entries(

--- a/warden/cloaking/patterns.py
+++ b/warden/cloaking/patterns.py
@@ -1,0 +1,124 @@
+"""Secret-detection pattern management for Prismor Warden cloaking.
+
+Two pattern sources, in priority order:
+
+  1. **Built-in** — ``builtin_patterns.txt`` shipped in this package. Conservative,
+     known-prefix credential formats. The single source of truth shared with the
+     bash hooks (``hooks/_patterns.sh`` reads the same file).
+  2. **Custom** — a user-editable file at ``$PRISMOR_HOME/cloak_patterns.txt``
+     (override with ``$PRISMOR_CLOAK_PATTERNS``) for org-specific token formats.
+
+Each line is one POSIX-ERE. Blank lines and ``#`` comments are ignored. The
+``warden cloak pattern`` CLI manages the custom file; built-ins are read-only.
+"""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import List
+
+# builtin_patterns.txt lives one directory up from this module.
+_BUILTIN_FILE = Path(__file__).resolve().parent / "builtin_patterns.txt"
+
+
+def builtin_patterns_file() -> Path:
+    """Path to the bundled, read-only pattern file."""
+    return _BUILTIN_FILE
+
+
+def custom_patterns_file() -> Path:
+    """Path to the user's editable custom-pattern file.
+
+    Honors ``$PRISMOR_CLOAK_PATTERNS``; otherwise ``$PRISMOR_HOME/cloak_patterns.txt``
+    (default ``~/.prismor/cloak_patterns.txt``). Mirrors ``hooks/_patterns.sh``.
+    """
+    override = os.environ.get("PRISMOR_CLOAK_PATTERNS")
+    if override:
+        return Path(override).expanduser()
+    home = Path(os.environ.get("PRISMOR_HOME", Path.home() / ".prismor"))
+    return home / "cloak_patterns.txt"
+
+
+def _read_patterns(path: Path) -> List[str]:
+    if not path.exists():
+        return []
+    out: List[str] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        out.append(line)
+    return out
+
+
+def builtin_patterns() -> List[str]:
+    """Return the bundled built-in patterns."""
+    return _read_patterns(_BUILTIN_FILE)
+
+
+def list_custom_patterns() -> List[str]:
+    """Return the user's custom patterns (empty if none registered)."""
+    return _read_patterns(custom_patterns_file())
+
+
+def all_patterns() -> List[str]:
+    """Built-ins followed by custom patterns — the effective detection set."""
+    return builtin_patterns() + list_custom_patterns()
+
+
+def add_pattern(regex: str) -> bool:
+    """Append ``regex`` to the custom pattern file.
+
+    Validates that the regex compiles before saving. Returns True if added,
+    False if it was already present (built-in or custom). Raises ``ValueError``
+    on an invalid regex.
+    """
+    regex = regex.strip()
+    if not regex:
+        raise ValueError("Pattern is empty.")
+    try:
+        re.compile(regex)
+    except re.error as exc:
+        raise ValueError(f"Invalid regex {regex!r}: {exc}") from exc
+
+    if regex in builtin_patterns() or regex in list_custom_patterns():
+        return False
+
+    path = custom_patterns_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        path.parent.chmod(0o700)
+    except PermissionError:
+        pass
+    if not path.exists():
+        header = (
+            "# Prismor Warden cloaking — custom (org-specific) secret patterns.\n"
+            "# One POSIX ERE per line. Managed by `warden cloak pattern add/remove`.\n"
+        )
+        path.write_text(header, encoding="utf-8")
+    with path.open("a", encoding="utf-8") as f:
+        f.write(regex + "\n")
+    return True
+
+
+def remove_pattern(regex: str) -> bool:
+    """Remove ``regex`` from the custom pattern file.
+
+    Returns True if a line was removed. Built-in patterns cannot be removed
+    (raises ``ValueError`` if ``regex`` is a built-in).
+    """
+    regex = regex.strip()
+    if regex in builtin_patterns():
+        raise ValueError(
+            f"{regex!r} is a built-in pattern and cannot be removed."
+        )
+    path = custom_patterns_file()
+    if not path.exists():
+        return False
+    lines = path.read_text(encoding="utf-8").splitlines()
+    kept = [ln for ln in lines if ln.strip() != regex]
+    if len(kept) == len(lines):
+        return False
+    path.write_text("\n".join(kept) + "\n", encoding="utf-8")
+    return True


### PR DESCRIPTION
## What

Adds a `PreToolUse` guard (`secret-guard.sh`) that catches **raw secrets the model emits directly** — a generated key, a value read from a file, or a credential copied into a command, file write, or MCP arg. On a match it vaults the value and **denies** the call with the placeholder to use instead. The raw value never executes, is never written, and never reaches the transcript or upstream API.

This complements the existing cloaking layer, which previously only covered the **paste** boundary (`userprompt-guard.sh`) and **placeholder substitution** (`decloak.sh`). The tool-call boundary was the gap.

> Note: while opening this PR, the `gh` command was itself blocked by `decloak.sh` because an earlier draft of this body contained a literal placeholder token — an incidental live confirmation that the hooks work.

## Key design choice

The guard **skips any value already present in the vault**, which makes it:
- **order-independent** vs `decloak.sh` — a legitimately decloaked value (placeholder to real) is recognized, not re-flagged
- **idempotent** across retries — first emit vaults + denies; the retry with the placeholder passes through
- compatible with manually-registered secrets

## Configurable patterns

Detection is now file-based. `builtin_patterns.txt` is the single source of truth shared by the bash hooks (`_patterns.sh`) and Python (`patterns.py`); `userprompt-guard.sh` is refactored onto it (no more duplicated regex). Org-specific formats:

```
warden cloak pattern add 'mycorp_[0-9a-f]{32}'
warden cloak pattern list / remove
```

## Scope of detection

- `Bash` -> scans `.command`
- `Write` / `Edit` / `MultiEdit` / `mcp__*` -> scans full tool input

Wired into the installer **before** `decloak.sh`, with a `--no-secret-guard` opt-out.

## Docs

- `docs/using-cloak.md` — practical setup, best practices, and threat model (linked from README). Notably documents that **direct reads of the plaintext vault are only blocked with the enforce-mode runtime monitor**, not by cloaking alone.
- Updated `warden/cloaking/README.md`.

## Testing

- `tests/test_cloak_secret_guard.py` — 23 checks (pattern mgmt + hook end-to-end: Bash/Write/MCP deny, idempotency, placeholder passthrough, custom patterns, invalid-regex rejection, built-in-removal refusal).
- Verified locally and on a Linux box (jq 1.7, Python 3.12): **23/23 pass**.

## Excluded

Pre-existing unrelated working-tree changes (`default_policy.yaml`, `hooks.py`, `scanner.py`, etc.) were intentionally left out of this commit.
