### PR TITLE
feat: add immunity-agent to skills.sh ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ See [benchmark.md](benchmark.md) for the full methodology, per-category breakdow
 
 ## Quick Start
 
+### Universal Install (55+ agents)
+
+Install to any supported agent (Claude Code, Cursor, Codex, OpenCode, GitHub Copilot, and [55+ more](https://github.com/vercel-labs/skills#supported-agents)) using the [skills CLI](https://skills.sh):
+
+```bash
+npx skills add PrismorSec/immunity-agent
+```
+
+Browse the skills directory: [skills.sh](https://skills.sh)
+
+### Platform-specific Install
+
 **Option A — pip (recommended):**
 
 ```bash

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: immunity-agent
+description: Use when setting up or working with Prismor Warden runtime security — installs policy enforcement, secret prevention, and supply-chain blocking for AI coding agents.
+---
+
+# immunity-agent: Runtime Security for AI Coding Agents
+
+## What It Does
+
+Warden runs as a hook layer that monitors every tool call your coding agent makes. It enforces security policies before the agent executes an action, preventing:
+
+- **Secret exfiltration** — blocks reads of `.env`, credential files, and raw secret values
+- **Dangerous shell commands** — blocks `rm -rf`, sudoers edits, CI pipeline modifications
+- **Supply-chain attacks** — scans npm/pip packages against a signed threat feed before install
+- **Prompt injection** — intercepts user-prompt payloads and flags injected instructions
+
+## Setup (run once per machine)
+
+```bash
+pip install immunity-agent
+warden setup          # interactive 5-step onboarding wizard
+```
+
+Pass `--non-interactive` for CI or scripted installs.
+
+## Modes
+
+| Mode | Behavior |
+|---|---|
+| `observe` (default) | Logs all tool calls and findings. Never blocks. Safe for onboarding and auditing. |
+| `enforce` | Blocks dangerous actions in real time before the agent executes them. |
+
+Switch modes at any time:
+
+```bash
+warden install-hooks --agent all --mode enforce    # block dangerous actions
+warden install-hooks --agent all --mode observe    # log only
+```
+
+## Key Commands
+
+```bash
+warden audit          # security audit of current session logs
+warden logs           # tail live session log
+warden status         # show hook installation and mode status
+warden cloak add KEY  # register a secret for cloaking
+```
+
+## Secret Cloaking
+
+Real secret values live under `~/.prismor/secrets/`. Reference them in tool calls as `@@SECRET:<name>@@` and the hook substitutes the real value at runtime without exposing it in context or transcripts.
+
+```bash
+warden cloak add stripe_key    # prompts for the value, stores it encrypted
+# then use @@SECRET:stripe_key@@ in commands — never the raw value
+```
+
+## Agent Behavior Rules
+
+- If Warden blocks an action, investigate the reason — do **not** attempt to bypass the hook or pass `--no-verify`
+- Reference secrets as `@@SECRET:<name>@@` rather than raw values in all tool calls
+- Run `warden audit` after completing multi-step tasks to verify no policy violations occurred
+- If `warden setup` has not been run, run it before proceeding with any agent task in the workspace

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "immunity-agent",
-  "version": "1.0.0",
+  "version": "1.5.1",
   "description": "Runtime security for AI coding agents: policy enforcement, secret prevention, and supply-chain blocking.",
   "license": "Apache-2.0",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "immunity-agent",
+  "version": "1.0.0",
+  "description": "Runtime security for AI coding agents: policy enforcement, secret prevention, and supply-chain blocking.",
+  "license": "Apache-2.0",
+  "keywords": [
+    "agent-skill",
+    "skills",
+    "security",
+    "warden",
+    "ai-agents",
+    "policy-enforcement",
+    "secret-prevention",
+    "supply-chain",
+    "claude-code",
+    "cursor",
+    "codex",
+    "opencode",
+    "github-copilot"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/PrismorSec/immunity-agent.git"
+  }
+}


### PR DESCRIPTION
## Summary

- **`SKILL.md`** — skill definition with YAML frontmatter (`name`, `description`) and full Warden usage guide (setup, modes, commands, secret cloaking, agent behavior rules). This is the file the `npx skills` CLI discovers and installs to any supported agent.
- **`package.json`** — lightweight manifest with `agent-skill` keyword for skills.sh directory indexing. No build role — Python packaging stays in `pyproject.toml`.
- **`README.md`** — adds a "Universal Install" section with `npx skills add PrismorSec/immunity-agent` above the existing platform-specific options, matching the pattern from [gpBlockchain/bug-hunt#7](https://github.com/gpBlockchain/bug-hunt/pull/7).

After merging, the skill can be installed to Claude Code, Cursor, Codex, OpenCode, GitHub Copilot, and 50+ other agents with:

```bash
npx skills add PrismorSec/immunity-agent
```

## Test plan

- [ ] Run `npx skills add PrismorSec/immunity-agent --list` after merge — should show `immunity-agent` with its description
- [ ] Run `npx skills add PrismorSec/immunity-agent -a claude-code -y` — should install `SKILL.md` into the Claude Code skills directory
- [ ] Verify `package.json` doesn't interfere with `pyproject.toml` or the Python build (`pip install .` still works)