### PR TITLE
fix: sort NVD CVEs by CVSS score before capping at 3

### DIFF
--- a/supplychain/scoring/engine.py
+++ b/supplychain/scoring/engine.py
@@ -72,7 +72,8 @@ class RiskScorer:
             # ── CVE scoring via NVD ──────────────────────────────────────────
             cves = fetch_cves(spec.name, meta.ecosystem)
             _CVE_POINTS = {"critical": 50, "high": 30, "medium": 15, "low": 5}
-            for cve in cves[:3]:  # cap at 3 to avoid output noise
+            cves_sorted = sorted(cves, key=lambda c: c.get("cvss_score") or 0, reverse=True)
+            for cve in cves_sorted[:3]:  # cap at 3 to avoid output noise
                 pts = _CVE_POINTS.get(cve["severity"], 0)
                 if pts:
                     add(f"nvd_{cve['severity']}", pts, cve["title"])


### PR DESCRIPTION
NVD returns results in arbitrary order, so the [:3] cap was silently dropping the highest-severity CVEs whenever lower-severity ones appeared first in the response. Sort descending by cvss_score first so the cap always removes the least-severe end of the list.