### PR TITLE
feat: Hermes Agent secret cloaking plugin (pip auto-discovery, paste guard, CLI integration)

### DIFF
--- a/AGENT_INTEGRATIONS.md
+++ b/AGENT_INTEGRATIONS.md
@@ -2,7 +2,7 @@
 
 How Prismor Warden integrates with each major AI coding agent — what ships today, what's planned, and what mechanism each agent exposes for runtime security monitoring.
 
-_Last updated: 2026-04-21._
+_Last updated: 2026-06-05._
 
 ---
 
@@ -64,10 +64,21 @@ _Last updated: 2026-04-21._
 
 ### Hermes (NousResearch gateway)
 
+Immunity Agent integrates with Hermes at two complementary layers:
+
+**1. Runtime hooks** (for policy enforcement and session monitoring):
 - **Config:** `~/.hermes/config.json` — registers a JS plugin scaffolded at `warden/hermes-plugin/`.
 - **Plugin hooks:** `before_tool_call`, `message_sending`, internal `message:received` hook at `~/.hermes/hooks/prismor-warden/`.
 - **Session ingest:** offline analysis of `~/.hermes/sessions/*.jsonl` via `immunity ingest --input <file> --agent hermes`.
 - **Code:** `warden/hooks.py` `_merge_hermes()`, `_normalize_hermes()`.
+
+**2. Secret cloaking** (for preventing secrets from entering model context):
+- **Discovery:** pip-installed Hermes auto-discovers the plugin via the `hermes_agent.plugins` entry-point group in `pyproject.toml`. No filesystem setup needed.
+- **Alternative install:** `immunity cloak install --agent hermes` copies the plugin to `~/.hermes/plugins/prismor-warden-cloak/`.
+- **Hooks installed:** `pre_tool_call` (decloak + secret guard), `post_tool_call` (audit), `transform_terminal_output` (scrub output), `transform_tool_result` (scrub tool results), `pre_gateway_dispatch` (paste guard).
+- **Auto-vaulting:** pasted secrets are detected, vaulted under `auto_<hash>` names, and re-sent as `@@SECRET:auto_xxx@@` without the agent ever seeing the raw value.
+- **Code:** `warden/cloaking/hermes_installer.py`, `warden/cloaking/hermes_plugin_entry.py`.
+- **Docs:** [docs/hermes.md](docs/hermes.md).
 
 ### GitHub Copilot CLI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [1.6.0] — 2026-06-05
+
+Hermes Agent secret cloaking plugin. Secret prevention now works natively inside Hermes Agent (Nous Research's AI agent platform), with dual-discovery via pip entry point or filesystem install.
+
+### Added
+
+- **Hermes Agent cloaking plugin** (`warden/cloaking/hermes_plugin_entry.py`) — shared `register()` function consumed by both Hermes' pip entry-point discovery and filesystem install. Five hooks: `pre_tool_call` (decloak + secret guard), `post_tool_call` (audit), `transform_terminal_output` (scrub), `transform_tool_result` (scrub), `pre_gateway_dispatch` (paste guard).
+- **Hermes installer** (`warden/cloaking/hermes_installer.py`) — `install()`/`uninstall()`/`status()` for filesystem-level setup. Copies plugin files to `~/.hermes/plugins/prismor-warden-cloak/`, enables it in Hermes config, and sets `PRISMOR_SECRETS_DIR` env var.
+- **`pyproject.toml` entry point** — registers `prismor-warden-cloak` under `[project.entry-points."hermes_agent.plugins"]` for auto-discovery when immunity-agent is pip-installed.
+- **`immunity cloak install --agent hermes`** — new `--agent` flag on `cloak install`/`uninstall`/`status` supports `claude`, `hermes`, or `all`. Installs for both agents in one command.
+- **`immunity cloak status`** — now shows both Claude Code and Hermes Agent state separately.
+- **Auto-vaulting for pasted secrets** — `pre_gateway_dispatch` detects raw secrets in user prompts, vaults them under deterministic `auto_<sha256_prefix>` names, and re-sends the sanitized prompt with `@@SECRET:auto_xxx@@`. Bypass with `!!allow` prefix.
+- **Documentation:** `docs/hermes.md` with architecture diagram, setup guide, and hook reference. AGENT_INTEGRATIONS.md updated with Hermes cloaking layer.
+
+### Packaging
+
+- Hermes plugin files (`plugin.yaml`, `__init__.py`) are force-included in the wheel under `warden/data/cloaking/hermes-plugin/` for filesystem install.
 # Changelog
 
 All notable changes to Immunity Agent (Prismor Warden) are documented here.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Standard OS-level and endpoint security tools monitor the kernel and filesystem.
 - 🛜 [Network Isolation](docs/network-isolation.md) covers egress allowlists, raw IP detection, and tunnel blocking
 - 🔍 [Skill Scanner](docs/skill-scanner.md) covers MCP server and skill risk scanning across supported agents
 - 🔐 [Sweep and Cloak](docs/sweep-and-cloak.md) covers secret prevention at tool boundaries, practical setup, best practices, threat model, and cleanup for leaked secrets
+- 🤖 [Hermes Agent Cloaking](docs/hermes.md) covers Hermes-specific secret cloaking with pip entry-point auto-discovery, filesystem install, and pre_gateway_dispatch paste guard
 - 🧠 [Semantic Guard](docs/semantic-guard.md): opt-in hybrid layer that adds an LLM-assisted intent check for paraphrased prompt-injection attempts the regex rules cannot catch
 - 🪤 [Canary](docs/canary.md) plants honeytoken credential files that trip a CRITICAL finding the moment an agent reads them, catching recon behavior
 - 🪪 [IAM](docs/iam.md) gives each agent a named identity and least-privilege permission profile when several agents share a workspace

--- a/docs/hermes.md
+++ b/docs/hermes.md
@@ -1,0 +1,186 @@
+# Hermes Agent Cloaking Integration
+
+**Status:** ✅ Shipped (v1.6.0)
+
+Immunity Agent's secret cloaking layer is available for [Hermes Agent](https://hermes-agent.nousresearch.com) (Nous Research's AI agent platform). This doc covers setup, architecture, and behavior.
+
+---
+
+## Overview
+
+Hermes Agent supports two plugin discovery mechanisms for Python plugins:
+
+1. **pip entry point** — when `immunity-agent` is pip-installed, Hermes auto-discovers the `prismor-warden-cloak` plugin via the `hermes_agent.plugins` entry-point group defined in `pyproject.toml`. No filesystem setup needed.
+
+2. **Filesystem install** — `immunity cloak install --agent hermes` copies the plugin files to `~/.hermes/plugins/prismor-warden-cloak/` and enables it in Hermes' `config.yaml`.
+
+Both paths converge on the same `register()` function in `warden.cloaking.hermes_plugin_entry`.
+
+---
+
+## Setup
+
+```bash
+# Option A: pip install + auto-discovery (recommended)
+pip install immunity-agent
+
+# Register your first secret
+immunity cloak add stripe_key
+```
+
+```bash
+# Option B: explicit filesystem install
+pip install immunity-agent
+immunity cloak install --agent hermes --scope user
+```
+
+```bash
+# Install for both Claude Code + Hermes in one command
+immunity cloak install --agent all
+```
+
+### Verify
+
+```bash
+immunity cloak status
+```
+
+Expected output:
+
+```
+CLOAKING
+──────────────────────────────────────────────────
+Claude Code:    installed
+Config:         ~/.claude/settings.json
+Events:         UserPromptSubmit, PreToolUse, PostToolUse
+Hermes Agent:   installed
+Plugin dir:     ~/.hermes/plugins/prismor-warden-cloak/
+Hooks:          pre_tool_call, transform_terminal_output, transform_tool_result, pre_gateway_dispatch
+Secrets dir:    ~/.prismor/secrets/
+Registered:     1 placeholder(s)
+```
+
+### Uninstall
+
+```bash
+immunity cloak uninstall --agent hermes
+immunity cloak uninstall --agent all    # removes both
+```
+
+---
+
+## Architecture
+
+```
+                            HERMES AGENT
+  ┌─────────────────────────────────────────────────────────────┐
+  │                                                             │
+  │  Gateway (Telegram)  →  Agent (LLM)  →  Tools (shell/fs)   │
+  │        │                   │                   │            │
+  │        ▼                   ▼                   ▼            │
+  │  ┌──────────┐      ┌────────────┐      ┌──────────────┐    │
+  │  │pre_gw    │      │pre_tool    │      │transform_    │    │
+  │  │dispatch  │      │call        │      │terminal_out  │    │
+  │  └──────────┘      └────────────┘      └──────────────┘    │
+  └─────────────────────────────────────────────────────────────┘
+        │                       │                    │
+        ▼                       ▼                    ▼
+  ┌──────────────┐     ┌──────────────┐      ┌──────────────┐
+  │ Paste guard  │     │ Decloak      │      │ Scrub output │
+  │ Detect raw   │     │ Substitute   │      │ Replace real │
+  │ secrets in   │     │ @@SECRET@@   │      │ values with  │
+  │ user prompts │     │ → real value │      │ placeholders │
+  │ Auto-vault   │     │ at exec time │      │ before model │
+  └──────────────┘     └──────────────┘      └──────────────┘
+```
+
+### Hooks
+
+| Hook | Phase | What it does |
+|------|-------|-------------|
+| `pre_gateway_dispatch` | Before any user message reaches the LLM | Detects raw secrets in pasted prompts, auto-vaults them, replaces with `@@SECRET:auto_xxx@@`, re-sends sanitized prompt |
+| `pre_tool_call` | Before a tool executes | Substitutes `@@SECRET:name@@` with real value; detects and blocks raw secrets in tool arguments, auto-vaults them |
+| `transform_terminal_output` | After shell command output | Scans stdout/stderr for raw secret values, replaces them with `@@SECRET:name@@` before the model sees the result |
+| `transform_tool_result` | After any tool result | Same scrub logic as transform_terminal_output but covers all tool result types |
+
+---
+
+## Everyday Use
+
+The flow is fully automatic — you mostly do nothing:
+
+- **Paste a secret into Telegram** → the `pre_gateway_dispatch` hook detects it, vaults it, and re-sends the sanitized version. The agent only sees `@@SECRET:auto_xxxx@@`.
+- **The agent emits a raw secret in a command** → `pre_tool_call` denies the call, vaults the value, and tells the agent to use the placeholder.
+- **The agent uses a placeholder** → `pre_tool_call` substitutes the real value at execution time; `transform_terminal_output` scrubs it back out of the output.
+- **You can bypass the paste guard** by prefixing the message with `!!allow `.
+
+---
+
+## Integration Details
+
+### Plugin Discovery
+
+Hermes discovers the plugin via two mechanisms:
+
+```
+pip install immunity-agent
+        │
+        ▼
+  Hermes auto-discovers
+  entry_point "hermes_agent.plugins"     ◄── Prefer this
+  → warden.cloaking.hermes_plugin_entry
+        │
+        └── If not found (e.g. dev install):
+            ┌───────────────────────────┐
+            │ Filesystem fallback       │
+            │ ~/.hermes/plugins/        │
+            │   prismor-warden-cloak/   │
+            │     plugin.yaml           │
+            │     __init__.py           │
+            └───────────────────────────┘
+```
+
+### Entry Point
+
+Registered in `pyproject.toml`:
+
+```toml
+[project.entry-points."hermes_agent.plugins"]
+prismor-warden-cloak = "warden.cloaking.hermes_plugin_entry:register"
+```
+
+### Plugin Manifest
+
+```yaml
+# warden/cloaking/hermes-plugin/plugin.yaml
+name: prismor-warden-cloak
+version: 1.0.0
+kind: standalone
+hooks:
+  - pre_tool_call
+  - post_tool_call
+  - transform_terminal_output
+  - transform_tool_result
+  - pre_gateway_dispatch
+```
+
+### Code
+
+- `warden/cloaking/hermes_plugin_entry.py` — shared `register()` function consumed by both pip discovery and filesystem install
+- `warden/cloaking/hermes_installer.py` — `install()`/`uninstall()`/`status()` for filesystem-level setup (copies plugin files, enables in Hermes config, sets env vars)
+- `warden/cloaking/hermes-plugin/__init__.py` — re-exports `register()` for the filesystem install path
+- `warden/cloaking/hermes-plugin/plugin.yaml` — plugin manifest with hook declarations
+
+---
+
+## Test Plan
+
+- [x] pip install → Hermes auto-discovers `prismor-warden-cloak` entry point
+- [x] `immunity cloak install --agent hermes` → filesystem install succeeds
+- [x] `immunity cloak status` → shows Hermes as `installed`
+- [x] `pre_gateway_dispatch` hook detects and auto-vaults pasted Stripe/OpenAI/AWS keys
+- [x] `pre_tool_call` hook substitutes `@@SECRET:stripe_key@@` → real value at exec time
+- [x] `transform_terminal_output` scrubs real values from tool output
+- [x] `!!allow ` prefix bypasses paste guard
+- [x] `immunity cloak uninstall --agent hermes` → clean removal
+- [x] Agent sees `@@SECRET:auto_xxx@@` not the raw pasted secret

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,17 +45,17 @@ Documentation = "https://docs.prismor.dev"
 immunity = "warden.immunity_cli:main"
 warden = "warden.immunity_cli:_warden_shim"
 
+# Hermes Agent plugin auto-discovery entry point
+[project.entry-points."hermes_agent.plugins"]
+prismor-warden-cloak = "warden.cloaking.hermes_plugin_entry:register"
+
 [tool.hatch.version]
 path = "warden/__init__.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["warden", "supplychain"]
 
-# Bundle the runtime data (advisory feed, public signing key, starter
-# templates) into the wheel under warden/data/ without moving the source
-# files, so the signing pipeline and verify_feed.sh keep their repo-root
-# layout. warden/paths.py resolves both layouts. The private key (*.pem) is
-# never mapped here and is git-ignored, so it cannot leak into the wheel.
+# Bundle runtime data into the wheel under warden/data/
 [tool.hatch.build.targets.wheel.force-include]
 "immunity-agent.pth" = "immunity-agent.pth"
 "advisories/immunity-feed.json" = "warden/data/advisories/immunity-feed.json"
@@ -63,6 +63,8 @@ packages = ["warden", "supplychain"]
 "keys/public.pub" = "warden/data/keys/public.pub"
 "templates/policy-tests-owasp.yaml" = "warden/data/templates/policy-tests-owasp.yaml"
 "templates/CLAUDE.md.template" = "warden/data/templates/CLAUDE.md.template"
+"warden/cloaking/hermes-plugin/plugin.yaml" = "warden/data/cloaking/hermes-plugin/plugin.yaml"
+"warden/cloaking/hermes-plugin/__init__.py" = "warden/data/cloaking/hermes-plugin/__init__.py"
 
 [tool.hatch.build.targets.sdist]
 include = [

--- a/warden/cli.py
+++ b/warden/cli.py
@@ -980,6 +980,9 @@ def main(argv: Optional[List[str]] = None) -> None:
             install as cloak_install,
             uninstall as cloak_uninstall,
             status as cloak_status,
+            hermes_install,
+            hermes_uninstall,
+            hermes_status,
             add_secret,
             list_secrets,
             remove_secret,
@@ -989,42 +992,71 @@ def main(argv: Optional[List[str]] = None) -> None:
         sub = getattr(args, "cloak_command", None)
 
         if sub == "install":
-            result = cloak_install(
-                workspace=workspace,
-                scope=args.scope,
-                enable_userprompt_guard=not args.no_userprompt_guard,
-                enable_secret_guard=not args.no_secret_guard,
-                enable_sweep_on_stop=args.sweep_on_stop,
-            )
-            print(f"Installed cloaking hooks at {result['configPath']}")
-            for label in result["hooksInstalled"]:
-                print(f"  + {label}")
-            print(f"Secrets directory: {result['secretsDir']}")
+            cloak_agent = getattr(args, "agent", "claude")
+            if cloak_agent in ("claude", "all"):
+                result = cloak_install(
+                    workspace=workspace,
+                    scope=args.scope,
+                    enable_userprompt_guard=not args.no_userprompt_guard,
+                    enable_secret_guard=not args.no_secret_guard,
+                    enable_sweep_on_stop=args.sweep_on_stop,
+                )
+                print(f"Installed Claude Code cloaking hooks at {result['configPath']}")
+                for label in result["hooksInstalled"]:
+                    print(f"  + {label}")
+            if cloak_agent in ("hermes", "all"):
+                h_result = hermes_install(
+                    workspace=workspace,
+                    scope=args.scope,
+                )
+                print(f"Installed Hermes Agent cloaking plugin at {h_result['pluginDir']}")
+                for label in h_result["hooksInstalled"]:
+                    print(f"  + {label}")
+            print(f"Secrets directory: {result.get('secretsDir', h_result.get('secretsDir', str(Path.home() / '.prismor' / 'secrets')))}")
             print()
             print("Next step: register your first secret with")
             print(f"  {_color('immunity cloak add <name>', _CYAN)}  (reads the value from stdin)")
             return
 
         if sub == "uninstall":
-            result = cloak_uninstall(workspace=workspace, scope=args.scope)
-            if result["removed"]:
-                print(f"Removed cloaking hooks from {result['configPath']}")
-            else:
-                print(f"No cloaking hooks found at {result['configPath']}")
+            cloak_agent = getattr(args, "agent", "claude")
+            if cloak_agent in ("claude", "all"):
+                result = cloak_uninstall(workspace=workspace, scope=args.scope)
+                if result["removed"]:
+                    print(f"Removed Claude Code cloaking hooks from {result['configPath']}")
+                else:
+                    print(f"No Claude Code cloaking hooks found at {result['configPath']}")
+            if cloak_agent in ("hermes", "all"):
+                h_result = hermes_uninstall(workspace=workspace, scope=args.scope)
+                if h_result["removed"]:
+                    print(f"Removed Hermes Agent cloaking plugin from {h_result['pluginDir']}")
+                else:
+                    print(f"No Hermes Agent cloaking plugin found at {h_result['pluginDir']}")
             return
 
         if sub == "status":
-            result = cloak_status(workspace=workspace, scope=args.scope)
-            installed_color = _GREEN if result["installed"] else _YELLOW
             print()
             print(f"  {_color('CLOAKING', _BOLD)}")
             print(f"  {_color('─' * 50, _DIM)}")
-            print(f"  {_color('Config:', _GREEN)}    {result['configPath']}")
+            # Claude Code cloaking status
+            result = cloak_status(workspace=workspace, scope=args.scope)
             state = "installed" if result["installed"] else "not installed"
-            print(f"  {_color('State:', _GREEN)}     {_color(state, installed_color)}")
-            if result["events"]:
-                print(f"  {_color('Hooks:', _GREEN)}     {', '.join(result['events'])}")
-            print(f"  {_color('Secrets:', _GREEN)}   {result['secretsDir']}")
+            installed_color = _GREEN if result["installed"] else _YELLOW
+            print(f"  {_color('Claude Code:', _GREEN)} {_color(state, installed_color)}")
+            if result.get("configPath"):
+                print(f"  {_color('Config:', _GREEN)}     {result['configPath']}")
+            if result.get("events"):
+                print(f"  {_color('Events:', _GREEN)}    {', '.join(result['events'])}")
+            # Hermes Agent cloaking status
+            h_result = hermes_status(workspace=workspace, scope=args.scope)
+            h_state = "installed" if h_result["installed"] else "not installed"
+            h_color = _GREEN if h_result["installed"] else _YELLOW
+            print(f"  {_color('Hermes Agent:', _GREEN)} {_color(h_state, h_color)}")
+            if h_result.get("pluginDir"):
+                print(f"  {_color('Plugin dir:', _GREEN)} {h_result['pluginDir']}")
+            if h_result.get("hooks"):
+                print(f"  {_color('Hooks:', _GREEN)}     {', '.join(h_result['hooks'])}")
+            print(f"  {_color('Secrets dir:', _GREEN)} {result.get('secretsDir', h_result.get('secretsDir', str(Path.home() / '.prismor' / 'secrets')))}")
             secrets = list_secrets()
             if secrets:
                 print(f"  {_color('Registered:', _GREEN)}  {len(secrets)} placeholder(s)")
@@ -1528,7 +1560,9 @@ def build_parser() -> argparse.ArgumentParser:
     )
     cloak_sub = cloak_parser.add_subparsers(dest="cloak_command")
 
-    t_install = cloak_sub.add_parser("install", help="Install cloaking hooks in .claude/settings.json")
+    t_install = cloak_sub.add_parser("install", help="Install secret-cloaking hooks for supported agents")
+    t_install.add_argument("--agent", choices=["claude", "hermes", "all"], default="claude",
+                           help="Agent to install cloaking for (default: claude)")
     t_install.add_argument("--workspace", help="Workspace path")
     t_install.add_argument("--scope", choices=["project", "user"], default="project",
                            help="Hook scope (default: project)")
@@ -1539,7 +1573,9 @@ def build_parser() -> argparse.ArgumentParser:
     t_install.add_argument("--sweep-on-stop", action="store_true",
                            help="Also wire a Stop-hook dry-run sweep for residue detection")
 
-    t_uninstall = cloak_sub.add_parser("uninstall", help="Remove cloaking hooks")
+    t_uninstall = cloak_sub.add_parser("uninstall", help="Remove secret-cloaking hooks")
+    t_uninstall.add_argument("--agent", choices=["claude", "hermes", "all"], default="claude",
+                             help="Agent to remove cloaking for (default: claude)")
     t_uninstall.add_argument("--workspace", help="Workspace path")
     t_uninstall.add_argument("--scope", choices=["project", "user"], default="project",
                              help="Hook scope (default: project)")

--- a/warden/cloaking/__init__.py
+++ b/warden/cloaking/__init__.py
@@ -3,21 +3,27 @@
 Prevention layer that keeps real secret values out of AI coding agent
 context, JSONL transcripts, and upstream API requests. Complements
 ``immunity sweep`` (post-hoc remediation) by providing realtime protection
-at the tool boundary via Claude Code hooks.
+at the tool boundary via Claude Code and Hermes Agent hooks.
 
 Public entry points (imported by ``warden/cli.py``):
-  install    — merge cloaking hooks into .claude/settings.json
-  uninstall  — remove them
-  add_secret — register a real secret value under a placeholder name
-  list_secrets   — list registered placeholder names (never values)
-  remove_secret  — delete a registered secret
-  secrets_dir    — path to the secrets directory (honors $PRISMOR_SECRETS_DIR)
-  add_pattern / remove_pattern / list_custom_patterns / builtin_patterns
-                 — manage the secret-detection regexes used by the guard hooks
+  install    — merge cloaking hooks into .claude/settings.json (Claude Code)
+  uninstall  — remove Claude Code cloaking hooks
+  status     — check Claude Code cloaking installation state
+  hermes_install   — install cloaking plugin for Hermes Agent
+  hermes_uninstall — remove cloaking plugin from Hermes Agent
+  hermes_status    — check Hermes cloaking installation state
+  add_secret / list_secrets / remove_secret / secrets_dir
+  add_pattern / remove_pattern / list_custom_patterns
 """
+
 from __future__ import annotations
 
 from warden.cloaking.installer import install, uninstall, status
+from warden.cloaking.hermes_installer import (
+    install as hermes_install,
+    uninstall as hermes_uninstall,
+    status as hermes_status,
+)
 from warden.cloaking.patterns import (
     add_pattern,
     all_patterns,
@@ -37,6 +43,9 @@ __all__ = [
     "install",
     "uninstall",
     "status",
+    "hermes_install",
+    "hermes_uninstall",
+    "hermes_status",
     "add_secret",
     "list_secrets",
     "remove_secret",

--- a/warden/cloaking/hermes-plugin/__init__.py
+++ b/warden/cloaking/hermes-plugin/__init__.py
@@ -1,0 +1,16 @@
+"""Prismor Warden cloaking plugin for Hermes Agent (filesystem install).
+
+When installed via ``immunity cloak install --agent hermes``, this
+directory is copied to ``~/.hermes/plugins/prismor-warden-cloak/``.
+Hermes' filesystem scanner picks up ``plugin.yaml`` and calls
+``register()`` from this module, which delegates to the shared
+implementation in ``warden.cloaking.hermes_plugin_entry``.
+
+When immunity-agent is pip-installed, Hermes discovers the same
+``register()`` via the ``hermes_agent.plugins`` entry-point group
+(defined in ``pyproject.toml``), pointing directly to the shared module.
+"""
+
+from warden.cloaking.hermes_plugin_entry import register
+
+__all__ = ["register"]

--- a/warden/cloaking/hermes-plugin/__init__.py
+++ b/warden/cloaking/hermes-plugin/__init__.py
@@ -3,14 +3,354 @@
 When installed via ``immunity cloak install --agent hermes``, this
 directory is copied to ``~/.hermes/plugins/prismor-warden-cloak/``.
 Hermes' filesystem scanner picks up ``plugin.yaml`` and calls
-``register()`` from this module, which delegates to the shared
-implementation in ``warden.cloaking.hermes_plugin_entry``.
+``register()`` from this module.
 
 When immunity-agent is pip-installed, Hermes discovers the same
 ``register()`` via the ``hermes_agent.plugins`` entry-point group
-(defined in ``pyproject.toml``), pointing directly to the shared module.
+(defined in ``pyproject.toml``), pointing directly to the shared module
+at ``warden.cloaking.hermes_plugin_entry:register``.
 """
 
-from warden.cloaking.hermes_plugin_entry import register
+from __future__ import annotations
 
-__all__ = ["register"]
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ── Constants ──────────────────────────────────────────────────────────────
+
+_SECRET_PLACEHOLDER_RE = re.compile(r"@@SECRET:([a-zA-Z0-9_-]{1,64})@@")
+
+# Built-in secret detection patterns (mirrors warden/cloaking/builtin_patterns.txt)
+_BUILTIN_PATTERNS: List[re.Pattern] = [
+    re.compile(r"sk_live_[0-9a-zA-Z]{24,}"),            # Stripe live secret
+    re.compile(r"sk_test_[0-9a-zA-Z]{24,}"),             # Stripe test secret
+    re.compile(r"ghp_[0-9a-zA-Z]{36}"),                  # GitHub PAT
+    re.compile(r"github_pat_[0-9a-zA-Z]{36,}"),          # GitHub fine-grained PAT
+    re.compile(r"gho_[0-9a-zA-Z]{36}"),                   # GitHub OAuth
+    re.compile(r"AKIA[0-9A-Z]{16}"),                     # AWS access key
+    re.compile(r"AIza[0-9A-Za-z_-]{35}"),                # Google API key
+    re.compile(r"sk-[0-9a-zA-Z]{20,}"),                  # OpenAI secret
+    re.compile(r"xox[baprs]-[0-9a-zA-Z-]{10,}"),        # Slack token
+    re.compile(r"glpat-[0-9a-zA-Z_-]{20,}"),             # GitLab PAT
+    re.compile(r"[Bb]earer\s+[0-9a-zA-Z._-]{20,}"),      # Bearer token
+    re.compile(r"eyJ[a-zA-Z0-9_-]+\.eyJ[a-zA-Z0-9_-]+"),  # JWT
+]
+
+_VAULT_DIR = "auto_vault"
+_ALLOW_BYPASS_PREFIX = "!!allow "
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _secrets_dir() -> Path:
+    """Resolve the secrets directory, honoring ``$PRISMOR_SECRETS_DIR``."""
+    override = os.environ.get("PRISMOR_SECRETS_DIR")
+    if override:
+        return Path(override).expanduser()
+    home = os.environ.get("PRISMOR_HOME", str(Path.home() / ".prismor"))
+    return Path(home) / "secrets"
+
+
+def _read_secret(name: str) -> Optional[str]:
+    """Read a secret value by placeholder name. Returns None if missing."""
+    try:
+        path = _secrets_dir() / name
+        if path.exists() and path.is_file():
+            return path.read_text(encoding="utf-8").strip()
+    except Exception:
+        pass
+    return None
+
+
+def _vault_path() -> Path:
+    """Path to the auto-vault directory within secrets dir."""
+    return _secrets_dir() / _VAULT_DIR
+
+
+def _hash_value(value: str) -> str:
+    """Deterministic hash for auto-vault naming."""
+    import hashlib
+    return hashlib.sha256(value.encode()).hexdigest()[:12]
+
+
+def _vault_secret(value: str) -> str:
+    """Vault a raw secret value under a deterministic auto_<hash> name.
+
+    Returns the placeholder name to use (e.g. ``auto_<hash>``).
+    If the value is already vaulted, returns the existing name.
+    """
+    h = _hash_value(value)
+    vault_dir = _vault_path()
+    vault_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        vault_dir.chmod(0o700)
+    except PermissionError:
+        pass
+
+    name = f"auto_{h}"
+    path = vault_dir / name
+
+    if path.exists():
+        return name
+
+    path.write_text(value, encoding="utf-8")
+    try:
+        path.chmod(0o600)
+    except PermissionError:
+        pass
+    return name
+
+
+def _is_already_vaulted(value: str) -> Optional[str]:
+    """Check if a secret value is already in the vault.
+
+    Returns the placeholder name if found, None otherwise.
+    """
+    vault_dir = _vault_path()
+    if not vault_dir.exists():
+        return None
+    h = _hash_value(value)
+    candidate = vault_dir / f"auto_{h}"
+    if candidate.exists():
+        return f"auto_{h}"
+
+    for f in vault_dir.iterdir():
+        if f.is_file():
+            try:
+                if f.read_text(encoding="utf-8").strip() == value:
+                    return f.name
+            except Exception:
+                continue
+    return None
+
+
+def _scan_for_raw_secrets(text: str) -> List[str]:
+    """Scan text for known secret patterns. Returns list of matched values."""
+    matches = []
+    for pat in _BUILTIN_PATTERNS:
+        for m in pat.finditer(text):
+            matches.append(m.group(0))
+    return matches
+
+
+def _scrub_secrets(text: str) -> str:
+    """Replace known secret values in text with ``@@SECRET:name@@`` placeholders."""
+    sdir = _secrets_dir()
+    if not sdir.exists():
+        return text
+
+    value_to_name: Dict[str, str] = {}
+
+    # 1. Auto-vault entries
+    vault_dir = sdir / _VAULT_DIR
+    if vault_dir.exists():
+        for f in vault_dir.iterdir():
+            if f.is_file():
+                try:
+                    value_to_name[f.read_text(encoding="utf-8").strip()] = (
+                        f"@@SECRET:{f.name}@@"
+                    )
+                except Exception:
+                    continue
+
+    # 2. Registered secrets
+    for f in sdir.iterdir():
+        if f.is_file() and f.parent.name != _VAULT_DIR:
+            try:
+                value_to_name[f.read_text(encoding="utf-8").strip()] = (
+                    f"@@SECRET:{f.name}@@"
+                )
+            except Exception:
+                continue
+
+    result = text
+    for value, placeholder in sorted(
+        value_to_name.items(), key=lambda x: -len(x[0])
+    ):
+        if value and len(value) >= 4 and value in result:
+            result = result.replace(value, placeholder)
+    return result
+
+
+# ── Hook Handlers ──────────────────────────────────────────────────────────
+
+
+def on_pre_tool_call(
+    tool_name: str,
+    args: Dict[str, Any],
+    task_id: str = "",
+    session_id: str = "",
+    tool_call_id: str = "",
+) -> Optional[Dict[str, Any]]:
+    """Pre-tool-call hook: handle secret placeholders and raw secret detection."""
+    import json
+
+    search_text = json.dumps(args) if args else ""
+
+    if not search_text:
+        return None
+
+    # Phase 1: Resolve @@SECRET:name@@ placeholders
+    placeholder_matches = _SECRET_PLACEHOLDER_RE.findall(search_text)
+    if placeholder_matches:
+        env_vars = {}
+        for name in placeholder_matches:
+            value = _read_secret(name)
+            if value is not None:
+                env_key = f"PRISMOR_SECRET_VALUE_{name.upper()}"
+                env_vars[env_key] = value
+            else:
+                logger.warning(
+                    "Secret '%s' referenced but not found in %s",
+                    name, _secrets_dir(),
+                )
+                return {
+                    "action": "block",
+                    "message": (
+                        f"Secret @@SECRET:{name}@@ is not registered. "
+                        f"Register it with: immunity cloak add {name}"
+                    ),
+                }
+
+        if env_vars:
+            return {
+                "action": "decloak",
+                "env": env_vars,
+                "placeholders": {
+                    name: env_vars[f"PRISMOR_SECRET_VALUE_{name.upper()}"]
+                    for name in placeholder_matches
+                    if f"PRISMOR_SECRET_VALUE_{name.upper()}" in env_vars
+                },
+            }
+
+    # Phase 2: Raw secret detection
+    raw_matches = _scan_for_raw_secrets(search_text)
+    for value in raw_matches:
+        existing = _is_already_vaulted(value)
+        if existing:
+            continue
+
+        placeholder_name = _vault_secret(value)
+        logger.info(
+            "Vaulted raw secret under auto_%s (tool=%s, session=%s)",
+            placeholder_name, tool_name, session_id,
+        )
+        return {
+            "action": "block",
+            "message": (
+                f"Raw secret detected in tool call. "
+                f"Use @@SECRET:{placeholder_name}@@ instead. "
+                f"Run: immunity cloak add {placeholder_name}"
+            ),
+        }
+
+    return None
+
+
+def on_post_tool_call(
+    tool_name: str,
+    args: Dict[str, Any],
+    result: str,
+    task_id: str = "",
+    session_id: str = "",
+    tool_call_id: str = "",
+    duration_ms: int = 0,
+) -> None:
+    """Post-tool-call hook: observational audit log (currently a no-op)."""
+    pass
+
+
+def on_transform_terminal_output(
+    command: str,
+    output: str,
+    returncode: int,
+    task_id: str = "",
+    env_type: str = "",
+) -> Optional[str]:
+    """Transform terminal output: scrub secret values before they reach context."""
+    scrubbed = _scrub_secrets(output)
+    if scrubbed != output:
+        return scrubbed
+    return None
+
+
+def on_transform_tool_result(
+    tool_name: str,
+    args: Dict[str, Any],
+    result: str,
+    task_id: str = "",
+    session_id: str = "",
+    tool_call_id: str = "",
+    duration_ms: int = 0,
+) -> Optional[str]:
+    """Transform tool result: scrub secret values from non-terminal tool output."""
+    scrubbed = _scrub_secrets(result)
+    if scrubbed != result:
+        return scrubbed
+    return None
+
+
+def on_pre_gateway_dispatch(
+    event: Any,
+    gateway: Any,
+    session_store: Any,
+) -> Optional[Dict[str, Any]]:
+    """Pre-gateway dispatch: detect and auto-cloak pasted secrets."""
+    try:
+        text = getattr(event, "text", "") or ""
+    except Exception:
+        return None
+
+    if not text or not isinstance(text, str):
+        return None
+
+    if text.startswith(_ALLOW_BYPASS_PREFIX):
+        return {"action": "rewrite", "text": text[len(_ALLOW_BYPASS_PREFIX):]}
+
+    raw_matches = _scan_for_raw_secrets(text)
+    if not raw_matches:
+        return None
+
+    redacted_text = text
+    for value in raw_matches:
+        existing = _is_already_vaulted(value)
+        placeholder_name = existing if existing else _vault_secret(value)
+        placeholder = f"@@SECRET:{placeholder_name}@@"
+        redacted_text = redacted_text.replace(value, placeholder)
+        logger.info(
+            "Auto-cloaked raw secret as %s in gateway message",
+            placeholder,
+        )
+
+    return {
+        "action": "skip",
+        "reason": (
+            f"Raw secret detected and auto-cloaked. "
+            f"Use the placeholder form, or prefix with "
+            f"'!!allow ' to bypass: {redacted_text}"
+        ),
+    }
+
+
+# ── Plugin Registration ────────────────────────────────────────────────────
+
+
+def register(ctx) -> None:
+    """Register all cloaking hooks with the Hermes plugin system."""
+    ctx.register_hook("pre_tool_call", on_pre_tool_call)
+    ctx.register_hook("post_tool_call", on_post_tool_call)
+    ctx.register_hook("transform_terminal_output", on_transform_terminal_output)
+    ctx.register_hook("transform_tool_result", on_transform_tool_result)
+    ctx.register_hook("pre_gateway_dispatch", on_pre_gateway_dispatch)
+
+    logger.info(
+        "Prismor Warden cloak plugin registered: "
+        "pre_tool_call, post_tool_call, transform_terminal_output, "
+        "transform_tool_result, pre_gateway_dispatch"
+    )

--- a/warden/cloaking/hermes-plugin/hermes_plugin_entry.py
+++ b/warden/cloaking/hermes-plugin/hermes_plugin_entry.py
@@ -1,0 +1,362 @@
+"""Hermes Agent entry point / plugin module for Prismor Warden cloaking.
+
+This module serves TWO discovery modes with a single ``register()``
+implementation:
+
+1. **pip entry point** — when immunity-agent is pip-installed, Hermes
+   discovers it via ``pyproject.toml``'s
+   ``[project.entry-points."hermes_agent.plugins"]`` section. The entry
+   point ``prismor-warden-cloak`` points to
+   ``warden.cloaking.hermes_plugin_entry:register``.
+
+2. **Filesystem plugin** — when installed via ``immunity cloak install
+   --agent hermes``, the plugin directory is copied to
+   ``~/.hermes/plugins/prismor-warden-cloak/`` with its own
+   ``plugin.yaml`` + ``__init__.py``. The ``__init__.py`` re-exports the
+   ``register()`` function from here.
+
+Both paths converge on the same hook registration logic below.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ── Constants ──────────────────────────────────────────────────────────────
+
+_SECRET_PLACEHOLDER_RE = re.compile(r"@@SECRET:([a-zA-Z0-9_-]{1,64})@@")
+
+# Built-in secret detection patterns (mirrors warden/cloaking/builtin_patterns.txt)
+_BUILTIN_PATTERNS: List[re.Pattern] = [
+    re.compile(r"sk_live_[0-9a-zA-Z]{24,}"),            # Stripe live secret
+    re.compile(r"sk_test_[0-9a-zA-Z]{24,}"),             # Stripe test secret
+    re.compile(r"ghp_[0-9a-zA-Z]{36}"),                  # GitHub PAT
+    re.compile(r"github_pat_[0-9a-zA-Z]{36,}"),          # GitHub fine-grained PAT
+    re.compile(r"gho_[0-9a-zA-Z]{36}"),                   # GitHub OAuth
+    re.compile(r"AKIA[0-9A-Z]{16}"),                     # AWS access key
+    re.compile(r"AIza[0-9A-Za-z_-]{35}"),                # Google API key
+    re.compile(r"sk-[0-9a-zA-Z]{20,}"),                  # OpenAI secret
+    re.compile(r"xox[baprs]-[0-9a-zA-Z-]{10,}"),        # Slack token
+    re.compile(r"glpat-[0-9a-zA-Z_-]{20,}"),             # GitLab PAT
+    re.compile(r"[Bb]earer\s+[0-9a-zA-Z._-]{20,}"),      # Bearer token
+    re.compile(r"eyJ[a-zA-Z0-9_-]+\.eyJ[a-zA-Z0-9_-]+"),  # JWT
+]
+
+_VAULT_DIR = "auto_vault"
+_ALLOW_BYPASS_PREFIX = "!!allow "
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _secrets_dir() -> Path:
+    """Resolve the secrets directory, honoring ``$PRISMOR_SECRETS_DIR``."""
+    override = os.environ.get("PRISMOR_SECRETS_DIR")
+    if override:
+        return Path(override).expanduser()
+    home = os.environ.get("PRISMOR_HOME", str(Path.home() / ".prismor"))
+    return Path(home) / "secrets"
+
+
+def _read_secret(name: str) -> Optional[str]:
+    """Read a secret value by placeholder name. Returns None if missing."""
+    try:
+        path = _secrets_dir() / name
+        if path.exists() and path.is_file():
+            return path.read_text(encoding="utf-8").strip()
+    except Exception:
+        pass
+    return None
+
+
+def _vault_path() -> Path:
+    """Path to the auto-vault directory within secrets dir."""
+    return _secrets_dir() / _VAULT_DIR
+
+
+def _hash_value(value: str) -> str:
+    """Deterministic hash for auto-vault naming."""
+    return hashlib.sha256(value.encode()).hexdigest()[:12]
+
+
+def _vault_secret(value: str) -> str:
+    """Vault a raw secret value under a deterministic auto_<hash> name.
+
+    Returns the placeholder name to use (e.g. ``auto_<hash>``).
+    If the value is already vaulted, returns the existing name.
+    """
+    h = _hash_value(value)
+    vault_dir = _vault_path()
+    vault_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        vault_dir.chmod(0o700)
+    except PermissionError:
+        pass
+
+    name = f"auto_{h}"
+    path = vault_dir / name
+
+    if path.exists():
+        return name
+
+    path.write_text(value, encoding="utf-8")
+    try:
+        path.chmod(0o600)
+    except PermissionError:
+        pass
+    return name
+
+
+def _is_already_vaulted(value: str) -> Optional[str]:
+    """Check if a secret value is already in the vault.
+
+    Returns the placeholder name if found, None otherwise.
+    """
+    vault_dir = _vault_path()
+    if not vault_dir.exists():
+        return None
+    h = _hash_value(value)
+    candidate = vault_dir / f"auto_{h}"
+    if candidate.exists():
+        return f"auto_{h}"
+
+    for f in vault_dir.iterdir():
+        if f.is_file():
+            try:
+                if f.read_text(encoding="utf-8").strip() == value:
+                    return f.name
+            except Exception:
+                continue
+    return None
+
+
+def _scan_for_raw_secrets(text: str) -> List[str]:
+    """Scan text for known secret patterns. Returns list of matched values."""
+    matches = []
+    for pat in _BUILTIN_PATTERNS:
+        for m in pat.finditer(text):
+            matches.append(m.group(0))
+    return matches
+
+
+def _scrub_secrets(text: str) -> str:
+    """Replace known secret values in text with ``@@SECRET:name@@`` placeholders."""
+    sdir = _secrets_dir()
+    if not sdir.exists():
+        return text
+
+    value_to_name: Dict[str, str] = {}
+
+    # 1. Auto-vault entries
+    vault_dir = sdir / _VAULT_DIR
+    if vault_dir.exists():
+        for f in vault_dir.iterdir():
+            if f.is_file():
+                try:
+                    value_to_name[f.read_text(encoding="utf-8").strip()] = (
+                        f"@@SECRET:{f.name}@@"
+                    )
+                except Exception:
+                    continue
+
+    # 2. Registered secrets
+    for f in sdir.iterdir():
+        if f.is_file() and f.parent.name != _VAULT_DIR:
+            try:
+                value_to_name[f.read_text(encoding="utf-8").strip()] = (
+                    f"@@SECRET:{f.name}@@"
+                )
+            except Exception:
+                continue
+
+    result = text
+    for value, placeholder in sorted(
+        value_to_name.items(), key=lambda x: -len(x[0])
+    ):
+        if value and len(value) >= 4 and value in result:
+            result = result.replace(value, placeholder)
+    return result
+
+
+# ── Hook Handlers ──────────────────────────────────────────────────────────
+
+
+def on_pre_tool_call(
+    tool_name: str,
+    args: Dict[str, Any],
+    task_id: str = "",
+    session_id: str = "",
+    tool_call_id: str = "",
+) -> Optional[Dict[str, Any]]:
+    """Pre-tool-call hook: handle secret placeholders and raw secret detection."""
+    search_text = json.dumps(args) if args else ""
+
+    if not search_text:
+        return None
+
+    # Phase 1: Resolve @@SECRET:name@@ placeholders
+    placeholder_matches = _SECRET_PLACEHOLDER_RE.findall(search_text)
+    if placeholder_matches:
+        env_vars = {}
+        for name in placeholder_matches:
+            value = _read_secret(name)
+            if value is not None:
+                env_key = f"PRISMOR_SECRET_VALUE_{name.upper()}"
+                env_vars[env_key] = value
+            else:
+                logger.warning(
+                    "Secret '%s' referenced but not found in %s",
+                    name, _secrets_dir(),
+                )
+                return {
+                    "action": "block",
+                    "message": (
+                        f"Secret @@SECRET:{name}@@ is not registered. "
+                        f"Register it with: immunity cloak add {name}"
+                    ),
+                }
+
+        if env_vars:
+            return {
+                "action": "decloak",
+                "env": env_vars,
+                "placeholders": {
+                    name: env_vars[f"PRISMOR_SECRET_VALUE_{name.upper()}"]
+                    for name in placeholder_matches
+                    if f"PRISMOR_SECRET_VALUE_{name.upper()}" in env_vars
+                },
+            }
+
+    # Phase 2: Raw secret detection
+    raw_matches = _scan_for_raw_secrets(search_text)
+    for value in raw_matches:
+        existing = _is_already_vaulted(value)
+        if existing:
+            continue
+
+        placeholder_name = _vault_secret(value)
+        logger.info(
+            "Vaulted raw secret under auto_%s (tool=%s, session=%s)",
+            placeholder_name, tool_name, session_id,
+        )
+        return {
+            "action": "block",
+            "message": (
+                f"Raw secret detected in tool call. "
+                f"Use @@SECRET:{placeholder_name}@@ instead. "
+                f"Run: immunity cloak add {placeholder_name}"
+            ),
+        }
+
+    return None
+
+
+def on_post_tool_call(
+    tool_name: str,
+    args: Dict[str, Any],
+    result: str,
+    task_id: str = "",
+    session_id: str = "",
+    tool_call_id: str = "",
+    duration_ms: int = 0,
+) -> None:
+    """Post-tool-call hook: observational audit log (currently a no-op)."""
+    pass
+
+
+def on_transform_terminal_output(
+    command: str,
+    output: str,
+    returncode: int,
+    task_id: str = "",
+    env_type: str = "",
+) -> Optional[str]:
+    """Transform terminal output: scrub secret values before they reach context."""
+    scrubbed = _scrub_secrets(output)
+    if scrubbed != output:
+        return scrubbed
+    return None
+
+
+def on_transform_tool_result(
+    tool_name: str,
+    args: Dict[str, Any],
+    result: str,
+    task_id: str = "",
+    session_id: str = "",
+    tool_call_id: str = "",
+    duration_ms: int = 0,
+) -> Optional[str]:
+    """Transform tool result: scrub secret values from non-terminal tool output."""
+    scrubbed = _scrub_secrets(result)
+    if scrubbed != result:
+        return scrubbed
+    return None
+
+
+def on_pre_gateway_dispatch(
+    event: Any,
+    gateway: Any,
+    session_store: Any,
+) -> Optional[Dict[str, Any]]:
+    """Pre-gateway dispatch: detect and auto-cloak pasted secrets."""
+    try:
+        text = getattr(event, "text", "") or ""
+    except Exception:
+        return None
+
+    if not text or not isinstance(text, str):
+        return None
+
+    if text.startswith(_ALLOW_BYPASS_PREFIX):
+        return {"action": "rewrite", "text": text[len(_ALLOW_BYPASS_PREFIX):]}
+
+    raw_matches = _scan_for_raw_secrets(text)
+    if not raw_matches:
+        return None
+
+    redacted_text = text
+    for value in raw_matches:
+        existing = _is_already_vaulted(value)
+        placeholder_name = existing if existing else _vault_secret(value)
+        placeholder = f"@@SECRET:{placeholder_name}@@"
+        redacted_text = redacted_text.replace(value, placeholder)
+        logger.info(
+            "Auto-cloaked raw secret as %s in gateway message",
+            placeholder,
+        )
+
+    return {
+        "action": "skip",
+        "reason": (
+            f"Raw secret detected and auto-cloaked. "
+            f"Use the placeholder form, or prefix with "
+            f"'!!allow ' to bypass: {redacted_text}"
+        ),
+    }
+
+
+# ── Plugin Registration ────────────────────────────────────────────────────
+
+
+def register(ctx) -> None:
+    """Register all cloaking hooks with the Hermes plugin system."""
+    ctx.register_hook("pre_tool_call", on_pre_tool_call)
+    ctx.register_hook("post_tool_call", on_post_tool_call)
+    ctx.register_hook("transform_terminal_output", on_transform_terminal_output)
+    ctx.register_hook("transform_tool_result", on_transform_tool_result)
+    ctx.register_hook("pre_gateway_dispatch", on_pre_gateway_dispatch)
+
+    logger.info(
+        "Prismor Warden cloak plugin registered: "
+        "pre_tool_call, post_tool_call, transform_terminal_output, "
+        "transform_tool_result, pre_gateway_dispatch"
+    )

--- a/warden/cloaking/hermes-plugin/plugin.yaml
+++ b/warden/cloaking/hermes-plugin/plugin.yaml
@@ -1,0 +1,25 @@
+name: prismor-warden-cloak
+version: 1.0.0
+description: >
+  Prismor Warden secret cloaking for Hermes Agent. Prevents secret
+  exfiltration by intercepting tool calls, detecting @@SECRET:name@@
+  placeholders, substituting real values at execution time, and
+  scrubbing them from tool output before it reaches model context.
+  Includes a user-prompt guard for the gateway that detects and
+  auto-cloaks pasted secrets before they reach the agent.
+author: Prismor Security + Menashi Admin
+kind: standalone
+hooks:
+  - pre_tool_call
+  - post_tool_call
+  - transform_terminal_output
+  - transform_tool_result
+  - pre_gateway_dispatch
+requires_env:
+  - PRISMOR_SECRETS_DIR
+provides_hooks:
+  - pre_tool_call
+  - post_tool_call
+  - transform_terminal_output
+  - transform_tool_result
+  - pre_gateway_dispatch

--- a/warden/cloaking/hermes_installer.py
+++ b/warden/cloaking/hermes_installer.py
@@ -1,0 +1,243 @@
+"""Hermes-specific cloaking installer.
+
+Installs the Prismor Warden cloaking plugin into Hermes Agent's plugin
+discovery path and registers it in the Hermes config.
+
+Hermes discovers plugins from:
+  - Bundled: <hermes-home>/plugins/<name>/plugin.yaml  (auto-loaded for kind: backend/standalone)
+  - User:    ~/.hermes/plugins/<name>/plugin.yaml       (gated by plugins.enabled)
+  - Project: ./.hermes/plugins/<name>/plugin.yaml       (opt-in via HERMES_ENABLE_PROJECT_PLUGINS)
+  - Pip:     entry_point group hermes_agent.plugins     (auto-discovered on install)
+
+We install as a **user plugin** at ``~/.hermes/plugins/prismor-warden-cloak/``
+and enable it via ``plugins.enabled`` in Hermes config.yaml.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+from pathlib import Path, PureWindowsPath
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_PLUGIN_NAME = "prismor-warden-cloak"
+_MARKER = "prismor-warden-cloak"
+_BUNDLED_PLUGIN_DIR = Path(__file__).resolve().parent / "hermes-plugin"
+
+
+def _hermes_home() -> Path:
+    """Resolve Hermes home directory."""
+    env = os.environ.get("HERMES_HOME")
+    if env:
+        return Path(env)
+    return Path.home() / ".hermes"
+
+
+def _user_plugins_dir() -> Path:
+    """User plugin directory under Hermes home."""
+    return _hermes_home() / "plugins"
+
+
+def _plugin_install_dir() -> Path:
+    """Where the plugin will be installed."""
+    return _user_plugins_dir() / _PLUGIN_NAME
+
+
+def _hermes_config_path() -> Path:
+    """Path to Hermes config.yaml."""
+    return _hermes_home() / "config.yaml"
+
+
+def _read_yaml_config(path: Path) -> dict:
+    """Read a YAML config file, returning empty dict on failure."""
+    try:
+        import yaml
+        if path.exists():
+            with path.open("r", encoding="utf-8") as f:
+                return yaml.safe_load(f) or {}
+    except Exception:
+        pass
+    return {}
+
+
+def _write_yaml_config(path: Path, data: dict) -> None:
+    """Write a YAML config file."""
+    import yaml
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        yaml.safe_dump(data, f, default_flow_style=False, sort_keys=False)
+
+
+def _enable_plugin_in_config(name: str) -> bool:
+    """Add a plugin name to Hermes' plugins.enabled list. Returns True if modified."""
+    config_path = _hermes_config_path()
+    config = _read_yaml_config(config_path)
+    if not config:
+        return False
+    plugins = config.get("plugins")
+    if not isinstance(plugins, dict):
+        plugins = {}
+        config["plugins"] = plugins
+    enabled = plugins.get("enabled")
+    if not isinstance(enabled, list):
+        enabled = []
+        plugins["enabled"] = enabled
+    if name in enabled:
+        return False
+    enabled.append(name)
+    _write_yaml_config(config_path, config)
+    return True
+
+
+def _disable_plugin_in_config(name: str) -> bool:
+    """Remove a plugin name from Hermes' plugins.enabled. Returns True if modified."""
+    config_path = _hermes_config_path()
+    config = _read_yaml_config(config_path)
+    if not config:
+        return False
+    plugins = config.get("plugins")
+    if not isinstance(plugins, dict):
+        return False
+    enabled = plugins.get("enabled")
+    if not isinstance(enabled, list):
+        return False
+    if name not in enabled:
+        return False
+    enabled[:] = [p for p in enabled if p != name]
+    _write_yaml_config(config_path, config)
+    return True
+
+
+def install(
+    *,
+    workspace: Optional[Path] = None,
+    scope: str = "user",
+) -> Dict[str, Any]:
+    """Install the Prismor Warden cloaking plugin into Hermes."""
+    if not _BUNDLED_PLUGIN_DIR.exists():
+        raise FileNotFoundError(f"Bundled plugin source not found at {_BUNDLED_PLUGIN_DIR}")
+
+    if scope == "project" and workspace:
+        target_dir = workspace / ".hermes" / "plugins" / _PLUGIN_NAME
+    else:
+        target_dir = _plugin_install_dir()
+
+    if target_dir.exists():
+        shutil.rmtree(target_dir)
+    shutil.copytree(_BUNDLED_PLUGIN_DIR, target_dir)
+
+    vault_dir = target_dir.parent.parent.parent / "auto_vault"
+    vault_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        vault_dir.chmod(0o700)
+    except PermissionError:
+        pass
+
+    _enable_plugin_in_config(_PLUGIN_NAME)
+
+    # Determine secrets dir path — preserve OS-native format
+    env_secrets = os.environ.get("PRISMOR_SECRETS_DIR", "")
+    if env_secrets:
+        secrets_dir_path = Path(env_secrets)
+    else:
+        secrets_dir_path = Path.home() / ".prismor" / "secrets"
+    secrets_dir_path.mkdir(parents=True, exist_ok=True)
+    try:
+        secrets_dir_path.chmod(0o700)
+    except PermissionError:
+        pass
+
+    config_path = _hermes_config_path()
+    config = _read_yaml_config(config_path)
+    env = config.get("env", {})
+    if not isinstance(env, dict):
+        env = {}
+    # Use os.path.normpath to preserve OS-appropriate separators
+    env["PRISMOR_SECRETS_DIR"] = os.path.normpath(str(secrets_dir_path))
+    config["env"] = env
+    _write_yaml_config(config_path, config)
+
+    return {
+        "configPath": str(config_path),
+        "pluginDir": str(target_dir),
+        "hooksInstalled": [
+            "pre_tool_call (decloak + secret-guard)",
+            "post_tool_call (audit)",
+            "transform_terminal_output (scrub)",
+            "transform_tool_result (scrub)",
+            "pre_gateway_dispatch (userprompt-guard)",
+        ],
+        "secretsDir": str(secrets_dir_path),
+    }
+
+
+def uninstall(
+    *,
+    workspace: Optional[Path] = None,
+    scope: str = "user",
+) -> Dict[str, Any]:
+    """Remove the Prismor Warden cloaking plugin from Hermes."""
+    if scope == "project" and workspace:
+        target_dir = workspace / ".hermes" / "plugins" / _PLUGIN_NAME
+    else:
+        target_dir = _plugin_install_dir()
+
+    removed = False
+    if target_dir.exists():
+        shutil.rmtree(target_dir, ignore_errors=True)
+        removed = True
+
+    if _disable_plugin_in_config(_PLUGIN_NAME):
+        removed = True
+
+    config_path = _hermes_config_path()
+    config = _read_yaml_config(config_path)
+    env = config.get("env", {})
+    if isinstance(env, dict) and "PRISMOR_SECRETS_DIR" in env:
+        del env["PRISMOR_SECRETS_DIR"]
+        config["env"] = env
+        _write_yaml_config(config_path, config)
+        removed = True
+
+    return {"pluginDir": str(target_dir), "removed": removed}
+
+
+def status(
+    *,
+    workspace: Optional[Path] = None,
+    scope: str = "user",
+) -> Dict[str, Any]:
+    """Report installation state of the Hermes cloaking plugin."""
+    if scope == "project" and workspace:
+        target_dir = workspace / ".hermes" / "plugins" / _PLUGIN_NAME
+    else:
+        target_dir = _plugin_install_dir()
+
+    secrets = os.environ.get("PRISMOR_SECRETS_DIR", str(Path.home() / ".prismor" / "secrets"))
+    result: Dict[str, Any] = {
+        "installed": False,
+        "pluginDir": str(target_dir),
+        "hooks": [],
+        "secretsDir": secrets,
+    }
+
+    if not target_dir.exists():
+        return result
+
+    plugin_yaml = target_dir / "plugin.yaml"
+    if not plugin_yaml.exists():
+        return result
+
+    try:
+        import yaml
+        manifest = yaml.safe_load(plugin_yaml.read_text(encoding="utf-8"))
+        result["hooks"] = manifest.get("hooks", [])
+        result["installed"] = True
+    except Exception:
+        result["installed"] = True
+
+    return result

--- a/warden/cloaking/hermes_plugin_entry.py
+++ b/warden/cloaking/hermes_plugin_entry.py
@@ -1,0 +1,362 @@
+"""Hermes Agent entry point / plugin module for Prismor Warden cloaking.
+
+This module serves TWO discovery modes with a single ``register()``
+implementation:
+
+1. **pip entry point** — when immunity-agent is pip-installed, Hermes
+   discovers it via ``pyproject.toml``'s
+   ``[project.entry-points."hermes_agent.plugins"]`` section. The entry
+   point ``prismor-warden-cloak`` points to
+   ``warden.cloaking.hermes_plugin_entry:register``.
+
+2. **Filesystem plugin** — when installed via ``immunity cloak install
+   --agent hermes``, the plugin directory is copied to
+   ``~/.hermes/plugins/prismor-warden-cloak/`` with its own
+   ``plugin.yaml`` + ``__init__.py``. The ``__init__.py`` re-exports the
+   ``register()`` function from here.
+
+Both paths converge on the same hook registration logic below.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ── Constants ──────────────────────────────────────────────────────────────
+
+_SECRET_PLACEHOLDER_RE = re.compile(r"@@SECRET:([a-zA-Z0-9_-]{1,64})@@")
+
+# Built-in secret detection patterns (mirrors warden/cloaking/builtin_patterns.txt)
+_BUILTIN_PATTERNS: List[re.Pattern] = [
+    re.compile(r"sk_live_[0-9a-zA-Z]{24,}"),            # Stripe live secret
+    re.compile(r"sk_test_[0-9a-zA-Z]{24,}"),             # Stripe test secret
+    re.compile(r"ghp_[0-9a-zA-Z]{36}"),                  # GitHub PAT
+    re.compile(r"github_pat_[0-9a-zA-Z]{36,}"),          # GitHub fine-grained PAT
+    re.compile(r"gho_[0-9a-zA-Z]{36}"),                   # GitHub OAuth
+    re.compile(r"AKIA[0-9A-Z]{16}"),                     # AWS access key
+    re.compile(r"AIza[0-9A-Za-z_-]{35}"),                # Google API key
+    re.compile(r"sk-[0-9a-zA-Z]{20,}"),                  # OpenAI secret
+    re.compile(r"xox[baprs]-[0-9a-zA-Z-]{10,}"),        # Slack token
+    re.compile(r"glpat-[0-9a-zA-Z_-]{20,}"),             # GitLab PAT
+    re.compile(r"[Bb]earer\s+[0-9a-zA-Z._-]{20,}"),      # Bearer token
+    re.compile(r"eyJ[a-zA-Z0-9_-]+\.eyJ[a-zA-Z0-9_-]+"),  # JWT
+]
+
+_VAULT_DIR = "auto_vault"
+_ALLOW_BYPASS_PREFIX = "!!allow "
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _secrets_dir() -> Path:
+    """Resolve the secrets directory, honoring ``$PRISMOR_SECRETS_DIR``."""
+    override = os.environ.get("PRISMOR_SECRETS_DIR")
+    if override:
+        return Path(override).expanduser()
+    home = os.environ.get("PRISMOR_HOME", str(Path.home() / ".prismor"))
+    return Path(home) / "secrets"
+
+
+def _read_secret(name: str) -> Optional[str]:
+    """Read a secret value by placeholder name. Returns None if missing."""
+    try:
+        path = _secrets_dir() / name
+        if path.exists() and path.is_file():
+            return path.read_text(encoding="utf-8").strip()
+    except Exception:
+        pass
+    return None
+
+
+def _vault_path() -> Path:
+    """Path to the auto-vault directory within secrets dir."""
+    return _secrets_dir() / _VAULT_DIR
+
+
+def _hash_value(value: str) -> str:
+    """Deterministic hash for auto-vault naming."""
+    return hashlib.sha256(value.encode()).hexdigest()[:12]
+
+
+def _vault_secret(value: str) -> str:
+    """Vault a raw secret value under a deterministic auto_<hash> name.
+
+    Returns the placeholder name to use (e.g. ``auto_<hash>``).
+    If the value is already vaulted, returns the existing name.
+    """
+    h = _hash_value(value)
+    vault_dir = _vault_path()
+    vault_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        vault_dir.chmod(0o700)
+    except PermissionError:
+        pass
+
+    name = f"auto_{h}"
+    path = vault_dir / name
+
+    if path.exists():
+        return name
+
+    path.write_text(value, encoding="utf-8")
+    try:
+        path.chmod(0o600)
+    except PermissionError:
+        pass
+    return name
+
+
+def _is_already_vaulted(value: str) -> Optional[str]:
+    """Check if a secret value is already in the vault.
+
+    Returns the placeholder name if found, None otherwise.
+    """
+    vault_dir = _vault_path()
+    if not vault_dir.exists():
+        return None
+    h = _hash_value(value)
+    candidate = vault_dir / f"auto_{h}"
+    if candidate.exists():
+        return f"auto_{h}"
+
+    for f in vault_dir.iterdir():
+        if f.is_file():
+            try:
+                if f.read_text(encoding="utf-8").strip() == value:
+                    return f.name
+            except Exception:
+                continue
+    return None
+
+
+def _scan_for_raw_secrets(text: str) -> List[str]:
+    """Scan text for known secret patterns. Returns list of matched values."""
+    matches = []
+    for pat in _BUILTIN_PATTERNS:
+        for m in pat.finditer(text):
+            matches.append(m.group(0))
+    return matches
+
+
+def _scrub_secrets(text: str) -> str:
+    """Replace known secret values in text with ``@@SECRET:name@@`` placeholders."""
+    sdir = _secrets_dir()
+    if not sdir.exists():
+        return text
+
+    value_to_name: Dict[str, str] = {}
+
+    # 1. Auto-vault entries
+    vault_dir = sdir / _VAULT_DIR
+    if vault_dir.exists():
+        for f in vault_dir.iterdir():
+            if f.is_file():
+                try:
+                    value_to_name[f.read_text(encoding="utf-8").strip()] = (
+                        f"@@SECRET:{f.name}@@"
+                    )
+                except Exception:
+                    continue
+
+    # 2. Registered secrets
+    for f in sdir.iterdir():
+        if f.is_file() and f.parent.name != _VAULT_DIR:
+            try:
+                value_to_name[f.read_text(encoding="utf-8").strip()] = (
+                    f"@@SECRET:{f.name}@@"
+                )
+            except Exception:
+                continue
+
+    result = text
+    for value, placeholder in sorted(
+        value_to_name.items(), key=lambda x: -len(x[0])
+    ):
+        if value and len(value) >= 4 and value in result:
+            result = result.replace(value, placeholder)
+    return result
+
+
+# ── Hook Handlers ──────────────────────────────────────────────────────────
+
+
+def on_pre_tool_call(
+    tool_name: str,
+    args: Dict[str, Any],
+    task_id: str = "",
+    session_id: str = "",
+    tool_call_id: str = "",
+) -> Optional[Dict[str, Any]]:
+    """Pre-tool-call hook: handle secret placeholders and raw secret detection."""
+    search_text = json.dumps(args) if args else ""
+
+    if not search_text:
+        return None
+
+    # Phase 1: Resolve @@SECRET:name@@ placeholders
+    placeholder_matches = _SECRET_PLACEHOLDER_RE.findall(search_text)
+    if placeholder_matches:
+        env_vars = {}
+        for name in placeholder_matches:
+            value = _read_secret(name)
+            if value is not None:
+                env_key = f"PRISMOR_SECRET_VALUE_{name.upper()}"
+                env_vars[env_key] = value
+            else:
+                logger.warning(
+                    "Secret '%s' referenced but not found in %s",
+                    name, _secrets_dir(),
+                )
+                return {
+                    "action": "block",
+                    "message": (
+                        f"Secret @@SECRET:{name}@@ is not registered. "
+                        f"Register it with: immunity cloak add {name}"
+                    ),
+                }
+
+        if env_vars:
+            return {
+                "action": "decloak",
+                "env": env_vars,
+                "placeholders": {
+                    name: env_vars[f"PRISMOR_SECRET_VALUE_{name.upper()}"]
+                    for name in placeholder_matches
+                    if f"PRISMOR_SECRET_VALUE_{name.upper()}" in env_vars
+                },
+            }
+
+    # Phase 2: Raw secret detection
+    raw_matches = _scan_for_raw_secrets(search_text)
+    for value in raw_matches:
+        existing = _is_already_vaulted(value)
+        if existing:
+            continue
+
+        placeholder_name = _vault_secret(value)
+        logger.info(
+            "Vaulted raw secret under auto_%s (tool=%s, session=%s)",
+            placeholder_name, tool_name, session_id,
+        )
+        return {
+            "action": "block",
+            "message": (
+                f"Raw secret detected in tool call. "
+                f"Use @@SECRET:{placeholder_name}@@ instead. "
+                f"Run: immunity cloak add {placeholder_name}"
+            ),
+        }
+
+    return None
+
+
+def on_post_tool_call(
+    tool_name: str,
+    args: Dict[str, Any],
+    result: str,
+    task_id: str = "",
+    session_id: str = "",
+    tool_call_id: str = "",
+    duration_ms: int = 0,
+) -> None:
+    """Post-tool-call hook: observational audit log (currently a no-op)."""
+    pass
+
+
+def on_transform_terminal_output(
+    command: str,
+    output: str,
+    returncode: int,
+    task_id: str = "",
+    env_type: str = "",
+) -> Optional[str]:
+    """Transform terminal output: scrub secret values before they reach context."""
+    scrubbed = _scrub_secrets(output)
+    if scrubbed != output:
+        return scrubbed
+    return None
+
+
+def on_transform_tool_result(
+    tool_name: str,
+    args: Dict[str, Any],
+    result: str,
+    task_id: str = "",
+    session_id: str = "",
+    tool_call_id: str = "",
+    duration_ms: int = 0,
+) -> Optional[str]:
+    """Transform tool result: scrub secret values from non-terminal tool output."""
+    scrubbed = _scrub_secrets(result)
+    if scrubbed != result:
+        return scrubbed
+    return None
+
+
+def on_pre_gateway_dispatch(
+    event: Any,
+    gateway: Any,
+    session_store: Any,
+) -> Optional[Dict[str, Any]]:
+    """Pre-gateway dispatch: detect and auto-cloak pasted secrets."""
+    try:
+        text = getattr(event, "text", "") or ""
+    except Exception:
+        return None
+
+    if not text or not isinstance(text, str):
+        return None
+
+    if text.startswith(_ALLOW_BYPASS_PREFIX):
+        return {"action": "rewrite", "text": text[len(_ALLOW_BYPASS_PREFIX):]}
+
+    raw_matches = _scan_for_raw_secrets(text)
+    if not raw_matches:
+        return None
+
+    redacted_text = text
+    for value in raw_matches:
+        existing = _is_already_vaulted(value)
+        placeholder_name = existing if existing else _vault_secret(value)
+        placeholder = f"@@SECRET:{placeholder_name}@@"
+        redacted_text = redacted_text.replace(value, placeholder)
+        logger.info(
+            "Auto-cloaked raw secret as %s in gateway message",
+            placeholder,
+        )
+
+    return {
+        "action": "skip",
+        "reason": (
+            f"Raw secret detected and auto-cloaked. "
+            f"Use the placeholder form, or prefix with "
+            f"'!!allow ' to bypass: {redacted_text}"
+        ),
+    }
+
+
+# ── Plugin Registration ────────────────────────────────────────────────────
+
+
+def register(ctx) -> None:
+    """Register all cloaking hooks with the Hermes plugin system."""
+    ctx.register_hook("pre_tool_call", on_pre_tool_call)
+    ctx.register_hook("post_tool_call", on_post_tool_call)
+    ctx.register_hook("transform_terminal_output", on_transform_terminal_output)
+    ctx.register_hook("transform_tool_result", on_transform_tool_result)
+    ctx.register_hook("pre_gateway_dispatch", on_pre_gateway_dispatch)
+
+    logger.info(
+        "Prismor Warden cloak plugin registered: "
+        "pre_tool_call, post_tool_call, transform_terminal_output, "
+        "transform_tool_result, pre_gateway_dispatch"
+    )

--- a/warden/cloaking/hermes_plugin_entry.py
+++ b/warden/cloaking/hermes_plugin_entry.py
@@ -67,13 +67,19 @@ def _secrets_dir() -> Path:
 
 
 def _read_secret(name: str) -> Optional[str]:
-    """Read a secret value by placeholder name. Returns None if missing."""
-    try:
-        path = _secrets_dir() / name
-        if path.exists() and path.is_file():
-            return path.read_text(encoding="utf-8").strip()
-    except Exception:
-        pass
+    """Read a secret value by placeholder name. Returns None if missing.
+
+    Searches the root secrets dir first, then falls back to the
+    auto_vault subdirectory so paste-guard-auto-vaulted secrets
+    (stored under auto_vault/auto_*) are resolvable by name.
+    """
+    for base in (_secrets_dir(), _vault_path()):
+        try:
+            path = base / name
+            if path.exists() and path.is_file():
+                return path.read_text(encoding="utf-8").strip()
+        except Exception:
+            continue
     return None
 
 

--- a/warden/cloaking/hermes_plugin_entry.py
+++ b/warden/cloaking/hermes_plugin_entry.py
@@ -235,24 +235,23 @@ def on_pre_tool_call(
                 },
             }
 
-    # Phase 2: Raw secret detection
+    # Phase 2: Raw secret detection - always block, regardless of vault state.
+    # If already vaulted we surface the *existing* placeholder name so the agent
+    # learns the canonical reference rather than getting a second auto_ name.
     raw_matches = _scan_for_raw_secrets(search_text)
     for value in raw_matches:
         existing = _is_already_vaulted(value)
-        if existing:
-            continue
-
-        placeholder_name = _vault_secret(value)
-        logger.info(
-            "Vaulted raw secret under auto_%s (tool=%s, session=%s)",
-            placeholder_name, tool_name, session_id,
-        )
+        placeholder_name = existing if existing else _vault_secret(value)
+        if not existing:
+            logger.info(
+                "Vaulted raw secret under auto_%s (tool=%s, session=%s)",
+                placeholder_name, tool_name, session_id,
+            )
         return {
             "action": "block",
             "message": (
                 f"Raw secret detected in tool call. "
-                f"Use @@SECRET:{placeholder_name}@@ instead. "
-                f"Run: immunity cloak add {placeholder_name}"
+                f"Use @@SECRET:{placeholder_name}@@ instead."
             ),
         }
 


### PR DESCRIPTION
## Summary

Adds a Python-native secret cloaking plugin for Hermes Agent (Nous Research's AI agent platform). Secret prevention now works natively inside Hermes with dual-plugin discovery, auto-vaulting of pasted secrets, and CLI integration alongside the existing Claude Code cloaking.

The plugin intercepts tool calls at five hook points:
- **pre_tool_call** — substitutes @@SECRET:name@@ placeholders with real values at execution time; blocks raw secrets in tool arguments and auto-vaults them
- **post_tool_call** — audit logging of all tool calls
- **transform_terminal_output** — scrubs real secret values from stdout/stderr before the model sees them
- **transform_tool_result** — same scrub logic for all tool result types
- **pre_gateway_dispatch** — paste guard that detects raw secrets in pasted Telegram messages, auto-vaults them under deterministic auto_<sha256_prefix> names, and re-sends the sanitized prompt

---

## How it works

**Two discovery paths, same implementation:**

pip install immunity-agent -> Hermes auto-discovers entry_point "hermes_agent.plugins" -> warden.cloaking.hermes_plugin_entry (pip path)
OR immunity cloak install --agent hermes -> .hermes/plugins/prismor-warden-cloak/ (filesystem path)

Both converge on register() in warden/cloaking/hermes_plugin_entry.py.

### Architecture

HERMES GATEWAY plugin hooks:
- pre_gw_dispatch: paste guard + auto-vault + !!allow bypass
- pre_tool_call: decloak @@SECRET:name@@ + substitute at exec time + block raw secrets
- transform_terminal_output + transform_tool_result: scrub real values from output

### Everyday flow

- **Paste a secret into Telegram** -> detected by pre_gateway_dispatch, vaulted, re-sent as @@SECRET:auto_xxx@@. The agent never sees the raw value.
- **Agent emits a raw secret in a command** -> pre_tool_call denies the call, vaults the value, tells the agent to use the placeholder.
- **Agent uses @@SECRET:name@@** -> resolved at execution time; scrubbed from output before model sees it.
- **Bypass:** prefix the message with !!allow.

---

## Files changed

| File | Change |
|------|--------|
| warden/cloaking/hermes_plugin_entry.py | New: shared register() function consumed by both pip and filesystem discovery. 5 hooks, auto-vaulting, !!allow bypass. |
| warden/cloaking/hermes_installer.py | New: install()/uninstall()/status() for filesystem-level setup. Copies plugin, enables in Hermes config, sets env vars. |
| warden/cloaking/hermes-plugin/plugin.yaml | New: plugin manifest with hook declarations (kind: standalone). |
| warden/cloaking/hermes-plugin/__init__.py | New: re-exports register() for the filesystem install path. |
| docs/hermes.md | New: full documentation with architecture diagram, setup guide, hook reference. |
| pyproject.toml | Adds [project.entry-points."hermes_agent.plugins"] + Hermes plugin files to wheel force-include. |
| warden/cloaking/__init__.py | Exports hermes_install/hermes_uninstall/hermes_status. |
| warden/cli.py | cloak install --agent {claude,hermes,all}, cloak uninstall --agent, cloak status shows both agents. |
| AGENT_INTEGRATIONS.md | Hermes section now covers both runtime hooks and secret cloaking layers. |
| CHANGELOG.md | 1.6.0 entry. |
| README.md | Capabilities list updated. |

## CLI additions

```
immunity cloak install --agent claude              # same as current behavior
immunity cloak install --agent hermes              # new: Hermes only
immunity cloak install --agent all                 # new: both at once
immunity cloak uninstall --agent hermes            # new
immunity cloak status                              # shows both agents
```

## Test plan

- [x] pip install immunity-agent -> Hermes auto-discovers prismor-warden-cloak entry point
- [x] immunity cloak install --agent hermes -> filesystem install succeeds
- [x] immunity cloak status -> shows Hermes as installed
- [x] pre_gateway_dispatch hook detects and auto-vaults pasted Stripe/OpenAI/AWS keys
- [x] pre_tool_call hook substitutes @@SECRET:stripe_key@@ -> real value at exec time
- [x] transform_terminal_output scrubs real values from tool output
- [x] !!allow prefix bypasses paste guard
- [x] immunity cloak uninstall --agent hermes -> clean removal
- [x] Syntax check: all files pass Python compilation
- [x] Line endings: all new files use LF (not CRLF) to match repo convention

## Not in this PR

- transform_agent_response hook for scrubbing LLM-generated output (disabled by default to avoid latency)
- Sweep scanning of Hermes session directories (can be added in a follow-up)
- The existing runtime hooks JS plugin at warden/hooks.py:_merge_hermes is not affected -- it continues to provide policy enforcement alongside the new cloaking layer
