### PR TITLE
chore: tag-triggered release workflow (PyPI + GitHub Releases)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write   # create GitHub Release
+  id-token: write   # OIDC token for PyPI trusted publishing
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: pypi
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build
+        run: |
+          pip install hatchling build
+          python -m build
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: dist/*
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/warden/cli.py
+++ b/warden/cli.py
@@ -1353,6 +1353,41 @@ def main(argv: Optional[List[str]] = None) -> None:
             print(format_learning_report(candidates, false_pos, refinements))
         return
 
+    if args.command == "update":
+        import subprocess
+        import urllib.request
+        import urllib.error
+        from warden import __version__ as _current
+        check_only = getattr(args, "check_only", False)
+        try:
+            with urllib.request.urlopen(
+                "https://pypi.org/pypi/immunity-agent/json", timeout=10
+            ) as resp:
+                latest = json.loads(resp.read())["info"]["version"]
+        except (urllib.error.URLError, KeyError, OSError) as exc:
+            sys.stderr.write(f"immunity update: could not reach PyPI — {exc}\n")
+            raise SystemExit(1)
+
+        if latest == _current:
+            print(f"immunity {_current} is already the latest version.")
+            return
+
+        print(f"Update available: {_current} → {latest}")
+        if check_only:
+            print("Run 'immunity update' (without --check) to install.")
+            return
+
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "install", "--upgrade", "immunity-agent"],
+            check=False,
+        )
+        if result.returncode == 0:
+            print(f"Updated to immunity-agent {latest}. Restart your shell or agent to use the new version.")
+        else:
+            sys.stderr.write("pip upgrade failed — check the output above.\n")
+            raise SystemExit(result.returncode)
+        return
+
     raise SystemExit(f"Unsupported command: {args.command}")
 
 
@@ -1699,6 +1734,17 @@ def build_parser() -> argparse.ArgumentParser:
         dest="cloak",
         action="store_false",
         help="Disable secret cloaking (non-interactive only)",
+    )
+
+    update_parser = subparsers.add_parser(
+        "update",
+        help="Check for and install the latest immunity-agent from PyPI",
+    )
+    update_parser.add_argument(
+        "--check",
+        dest="check_only",
+        action="store_true",
+        help="Show available update without installing",
     )
 
     return parser

--- a/warden/immunity_cli.py
+++ b/warden/immunity_cli.py
@@ -41,6 +41,7 @@ _TOP_LEVEL_SHORTCUTS = {
     "check", "scan", "deps", "semantic-check",
     "analyze", "ingest", "sessions", "session",
     "install-hooks", "uninstall-hooks", "hook-dispatch",
+    "update",
 }
 
 # Domains that map to a warden.cli subparser of the same name.
@@ -108,6 +109,7 @@ def _print_usage() -> None:
     print()
     print(f"  {b('Quick start')}")
     print(f"    immunity setup              {d('Interactive onboarding wizard')}")
+    print(f"    immunity update             {d('Check for and install the latest version')}")
     print(f"    immunity status             {d('One-shot health check: hooks, mode, cloak, latest session')}")
     print(f"    immunity audit              {d('Full security posture audit')}")
     print(f"    immunity info               {d('Workspace summary (deprecated alias of status)')}")


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` triggered on `v*` tags
- Builds the wheel with `hatchling`/`build`
- Creates a GitHub Release with auto-generated release notes + attaches the wheel/sdist as assets
- Publishes to PyPI via OIDC trusted publishing — no API token stored in secrets

## Pre-requisite before merging

Add a trusted publisher on PyPI at `https://pypi.org/manage/project/immunity-agent/settings/publishing/`:

| Field | Value |
|---|---|
| Owner | `PrismorSec` |
| Repository | `immunity-agent` |
| Workflow filename | `release.yml` |
| Environment | `pypi` |

Also create a `pypi` environment in the repo's GitHub Settings → Environments (optional but matches the `environment: pypi` in the workflow).

## How to ship a release after merging

```bash
# 1. bump __version__ in warden/__init__.py, commit + push to main
# 2. tag and push:
git tag v1.6.2
git push origin v1.6.2
```

The tag push kicks off the workflow — no further manual steps.