### PR TITLE
feat(warden): close prompt-injection benchmark false negatives

### DIFF
--- a/warden/default_policy.yaml
+++ b/warden/default_policy.yaml
@@ -204,7 +204,11 @@ rules:
     fields: [combined_text]
     patterns:
       # Instruction override — direct phrase attacks
-      - '(ignore\s+(all\s+)?(any\s+)?(previous\s+)?instructions|reveal\s+(your|the)\s+system\s+prompt|developer\s+instructions|exfiltrat(e|ion)|print\s+.*(secret|token|key|credential|password)|show\s+.*(token|secret|key|credential|password)|bypass(es|ed|ing)?\s+guardrails|jailbreak)'
+      - '(ignore\s+(all\s+)?(any\s+)?(previous\s+)?instructions|reveal\s+(your|the)\s+system\s+prompt|developer\s+instructions|exfiltrat(e|ion)|print\s+.*(secret|token|key|credential|password)|show\s+.*(token|secret|key|credential|password)|bypass(es|ed|ing)?\s+(safety\s+)?(restrictions?|guardrails?|safeguards?|controls?)|jailbreak)'
+      # System-prompt / instruction extraction via non-trigger verbs (repeat, translate, summarize, print, extract, inspect…)
+      - '(provide|share|reveal|disclose|show|give|repeat|translate|summari[sz]e|print|extract|inspect|dump|display|output)\s+.{0,60}((system|developer|initiali[sz]ation|internal)[\s-]*prompt|(your|hidden)\s+(instructions?|guidelines?|rules?|config\w*)|instructions?\s+you\s+(received|were\s+given)|internal\s+config\w*|conversation\s+history|hidden\s+context)'
+      # Memory / persistence poisoning — durable state injection to subvert future sessions
+      - '(remember\s+(this\s+)?(forever|permanently)|always\s+(trust|obey|follow)\s+.{0,30}(my|the\s+user).{0,20}(future\s+)?(instructions?|commands?))'
       # Covert exfiltration — natural-language instructions to send data without user awareness
       - '(?:silently|quietly|covertly|secretly)\s+(?:send|forward|transmit|upload|share|post)\b'
       - 'without\s+(?:the\s+)?user\s+(?:knowing|noticing|seeing|being\s+aware|realizing)'
@@ -214,6 +218,21 @@ rules:
       - '(?:appear|seem|act)\s+(?:helpful|friendly|trustworthy|cooperative)\s+(?:while|but\s+(?:actually|then)|before\s+(?:then|you))'
       - '(?:gain|build|establish)\s+(?:the\s+)?user(?:''s)?\s+trust\s+(?:and\s+then|before|so\s+that|in\s+order\s+to)'
     action: block
+
+  # ── MEDIUM: Bulk PII / dataset exfiltration framing ───────────────────
+  # Extraction aimed at whole datasets of personal data (employee emails,
+  # salaries, customer records), often framed as a benign codegen/summary
+  # task. Warn rather than block — legitimate admin/reporting tooling uses
+  # similar phrasing, so this surfaces for review without false-blocking.
+  - id: bulk-pii-exfiltration
+    severity: MEDIUM
+    category: prompt_injection
+    title: Flags requests to output/export whole datasets of personal data (PII)
+    event_types: [prompt, tool_result]
+    fields: [combined_text]
+    patterns:
+      - '(output|export|dump|list|generate|include|compile|extract)\s+.{0,40}(all|every|each|the\s+full|complete)\s+.{0,30}(employee|customer|user|client|personnel|staff|member|patient)\w*\s+.{0,20}(record|email|salary|salaries|address|phone|ssn|data|details?|info\w*|pii)'
+    action: warn
 
   # ── CRITICAL: Prompt injection hidden in HTML/CSS/invisible chars ─────
   # Catches payloads that survive the naive regex above because they are

--- a/warden/semantic_guard.py
+++ b/warden/semantic_guard.py
@@ -60,7 +60,7 @@ _sig(r"(already|previously)\s+(approved|authorized|granted|permitted)", 0.55, "f
 _sig(r"(the\s+)?(previous|prior|last)\s+(maintainer|admin|engineer|ciso|security\s+team)", 0.45, "authority_claim")
 _sig(r"(ciso|security\s+team|compliance\s+team|platform\s+team)\s+(has|have|already)", 0.55, "org_authority_claim")
 _sig(r"no\s+need\s+to\s+(check|verify|confirm|ask|validate)", 0.50, "skip_verification")
-_sig(r"(skip|bypass|disable|ignore)\s+(\w+\s+){0,2}(security|validation|check|permission|warden|hook)", 0.70, "explicit_bypass")
+_sig(r"(skip|bypass|disable|ignore)\s+(\w+\s+){0,2}(security|validation|check|permission|warden|hook|safety|restrictions?|safeguards?|guardrails?|controls?)", 0.70, "explicit_bypass")
 
 # Compliance / audit pretexts
 _sig(r"compliance\s+(requires|mandates|demands|needs)", 0.60, "compliance_pretext")
@@ -90,7 +90,7 @@ _sig(r"SYSTEM\s*:\s*(ignore|forget|override|you\s+are)", 0.90, "system_prompt_in
 _sig(r"ATTENTION\s+AI\s+(ASSISTANT|SYSTEM)", 0.80, "in_content_injection_marker")
 
 # Credential / secret extraction
-_sig(r"(provide|share|reveal|disclose|show|give)\s+.{0,60}(system.?prompt|your\s+instructions?|your\s+guidelines?|your\s+rules)", 0.70, "system_prompt_disclosure")
+_sig(r"(provide|share|reveal|disclose|show|give|repeat|translate|summari[sz]e|print|extract|inspect|dump|display|output)\s+.{0,60}((system|developer|initiali[sz]ation|internal)[\s-]*prompt|(your|hidden)\s+(instructions?|guidelines?|rules?|config\w*)|instructions?\s+you\s+(received|were\s+given)|internal\s+config\w*|conversation\s+history|hidden\s+context)", 0.70, "system_prompt_disclosure")
 _sig(r"(export|output|include|copy|dump)\s+.{0,60}(credential|secret|password|token|key|\.env|\.aws|shadow|passwd)", 0.75, "credential_exfil_request")
 _sig(r"(service\s+account\s+key|api\s+key|access\s+token)\s+.{0,40}(file|include|export)", 0.70, "credential_collection")
 _sig(r"(vendor|partner|support\s+team)\s+.{0,60}(credential|key|secret)", 0.60, "third_party_credential_share")
@@ -119,6 +119,15 @@ _sig(r"(grant|give).{0,40}(root\s+access|all\s+users|sudo|NOPASSWD)", 0.80, "pri
 _sig(r"\bexfiltrat", 0.40, "exfil_directive")
 _sig(r"(you\s+must\s+now|you\s+are\s+(required|instructed)\s+to)\s+.{0,120}(send|transmit|forward|exfiltrat|post|upload)\b", 0.70, "imperative_exfil_directive")
 _sig(r"(as\s+(a\s+)?(helpful|trusted|capable|responsible)\s+assistant)\b.{0,120}(you\s+must\s+now|you\s+are\s+(required|instructed)\s+to|must\s+now)", 0.55, "persona_directive_injection")
+
+# Memory / persistence poisoning — injects durable state to subvert future
+# sessions without any immediate exfil action (invisible to action-based rules).
+_sig(r"(remember\s+(this\s+)?(forever|permanently|always)|always\s+(trust|obey|follow)\s+.{0,30}(my|the\s+user).{0,20}(future\s+)?(instructions?|commands?|messages?)|store\s+this\s+(permanently|forever))", 0.65, "memory_poisoning")
+
+# Bulk PII / dataset exfiltration framing — whole-dataset extraction of
+# personal data, often disguised as a codegen or summarization task. Scored
+# in the warn band (not block): legitimate reporting tooling phrases similarly.
+_sig(r"(output|export|dump|list|generate|include|compile|extract)\s+.{0,40}(all|every|each|the\s+full|complete)\s+.{0,30}(employee|customer|user|client|personnel|staff|member|patient)\w*\s+.{0,20}(record|email|salary|salaries|address|phone|ssn|data|details?|info\w*|pii)", 0.55, "bulk_pii_exfil")
 
 
 def _heuristic_analyze(text: str) -> SemanticRisk:

--- a/warden/semantic_guard_v2.py
+++ b/warden/semantic_guard_v2.py
@@ -47,7 +47,7 @@ HIGH_THRESH = 0.75   # at or above this: block straight through
 _STRUCTURAL_RULES: List[Tuple[re.Pattern, re.Pattern, re.Pattern]] = [
     (
         re.compile(r"\b(compliance|audit|security\s+team|pre.?approved|administrator|authorized|ciso)\b", re.I),
-        re.compile(r"\b(you\s+must|must\s+now|you\s+need\s+to|now\s+provide|please\s+provide|you\s+are\s+required)\b", re.I),
+        re.compile(r"\b(you\s+must|must\s+now|you\s+need\s+to|now\s+provide|please\s+provide|you\s+are\s+required|reveal|disclose|display|inspect|show)\b", re.I),
         re.compile(r"\b(system.?prompt|instructions?|configuration|api\s+key|credentials?|secrets?|policy|settings)\b", re.I),
     ),
     (


### PR DESCRIPTION
## Summary

Closes detection gaps surfaced by the 20-category prompt-injection benchmark (`R-prompt-injection-benchmark-report.md`). The persistent false negatives were narrow regex/signal coverage, not model capacity — most fall into a few tight classes that each cost ~1 line to close. **Minimal footprint: 32 insertions / 4 deletions across 3 files.**

Deterministic YAML patterns improve **both** the vanilla and hybrid columns at zero LLM cost; each is mirrored as a heuristic signal for paraphrase robustness.

## Changes

| Class | Mechanism | Action | Closes |
|-------|-----------|--------|--------|
| Extraction via non-trigger verbs (`repeat/translate/summarize/print/extract/inspect…`) targeting self-referential prompt/instructions/config/history | YAML + heuristic | block | G002, G008–G011, G013, G014, G037, G038 |
| Bypass target widened: `guardrails` → `+safety/restrictions/safeguards/controls` | YAML + heuristic | block | G016 |
| Memory / persistence poisoning (new threat class) | YAML + heuristic | block | G033 |
| Bulk PII / dataset exfiltration framing | YAML + heuristic | **warn** | G034, G036 |
| Structural directive verbs widened | `semantic_guard_v2` (escalate-only) | escalate→LLM | reinforces G014/G002/G003/G013 |

PII-dump framing is `warn`, not `block` — legitimate admin/reporting tooling phrases similarly, so it surfaces for review without false-blocking.

## Validation

- All 13 targeted attack strings now match; the deterministic ones block in the vanilla layer too (recall improves in both modes).
- Benign near-misses verified clean — e.g. "Summarize the **build instructions**", "Translate … into French", "List **all the files** in the user directory" do **not** trip. Precision should hold at 1.000.
- **413 tests pass** (`pytest --ignore=tests/test_pipeline.py`; that module has a pre-existing unrelated `requests` import error).
- Deliberately **not** lowering escalation thresholds (would erode zero-FP); Base64 decode (G020) left out — only fix needing real new code for a single case.

## Follow-up
- Re-run the bench CSVs on `st3ve` to confirm FP=0 holds on the real benign controls.
- Optional: add regression-test assertions for the newly-covered IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)